### PR TITLE
Fix protobuf gradle protobuf dependencies

### DIFF
--- a/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
@@ -16,7 +16,6 @@ package build.buf.gradle
 
 import org.gradle.api.Task
 import java.io.File
-import java.nio.file.Path
 
 internal fun Task.execBufInSpecificDirectory(
     vararg bufCommand: String,

--- a/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
@@ -39,7 +39,7 @@ private fun Task.execBufInSpecificDirectory(
     customErrorMessage: ((String) -> String)? = null
 ) {
     fun runWithArgs(file: File? = null) =
-        bufCommand + listOfNotNull(file?.let { mangle(project.projectDir.toPath().relativize(it.toPath())) }) + extraArgs
+        bufCommand + listOfNotNull(file?.let { project.makeMangledRelativizedPathStr(it) }) + extraArgs
 
     when {
         project.hasProtobufGradlePlugin() ->

--- a/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
@@ -15,6 +15,7 @@
 package build.buf.gradle
 
 import org.gradle.api.Task
+import java.io.File
 import java.nio.file.Path
 
 internal fun Task.execBufInSpecificDirectory(
@@ -37,12 +38,12 @@ private fun Task.execBufInSpecificDirectory(
     extraArgs: Iterable<String>,
     customErrorMessage: ((String) -> String)? = null
 ) {
-    fun runWithArgs(path: Path? = null) =
-        bufCommand + listOfNotNull(path?.let(::mangle)) + extraArgs
+    fun runWithArgs(file: File? = null) =
+        bufCommand + listOfNotNull(file?.let { mangle(project.projectDir.toPath().relativize(it.toPath())) }) + extraArgs
 
     when {
         project.hasProtobufGradlePlugin() ->
-            project.srcProtoDirs().forEach { execBuf(runWithArgs(it), customErrorMessage) }
+            project.projectDefinedProtoDirs().forEach { execBuf(runWithArgs(it), customErrorMessage) }
         project.hasWorkspace() ->
             execBuf(bufCommand, customErrorMessage)
         else ->

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -107,8 +107,15 @@ private fun Task.workspaceSymLinkEntries() =
 private fun Task.allProtoDirs(): List<Path> =
     (project.srcProtoDirs() + extractProtoDirs()).filter { project.anyProtos(it) }
 
+// NOTE: The hard coded extractProtoDirs are removed from the source set directories fixes issue
+// https://github.com/bufbuild/buf-gradle-plugin/issues/132. Starting in version 0.9.2 of the
+// protobuf gradle plugin changed the directories in the proto srcDirs to include "extracted protos".
+//
+// Change that introduced this behavior: https://github.com/google/protobuf-gradle-plugin/pull/637/
+// Line: https://github.com/google/protobuf-gradle-plugin/blob/9d2a328a0d577bf4439d3b482a953715b3a03027/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy#L425
 internal fun Project.srcProtoDirs() =
-    (the<SourceSetContainer>().flatMap { it.protoDirs(this) } + androidSrcProtoDirs()).minus(extractProtoDirs())
+    (the<SourceSetContainer>().flatMap { it.protoDirs(this) } + androidSrcProtoDirs())
+        .minus(extractProtoDirs())
 
 private fun Project.androidSrcProtoDirs() =
     extensions.findByName("android")

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -58,7 +58,7 @@ abstract class CreateSymLinksToModulesTask : DefaultTask() {
     @TaskAction
     fun createSymLinksToModules() {
         allProtoDirs().forEach {
-            val symLinkFile = File(bufbuildDir, mangle(it))
+            val symLinkFile = File(bufbuildDir, project.makeMangledRelativizedPathStr(it))
             if (!symLinkFile.exists()) {
                 logger.info("Creating symlink for $it at $symLinkFile")
                 Files.createSymbolicLink(
@@ -102,23 +102,37 @@ private fun Task.workspaceCommonConfig() {
 }
 
 private fun Task.workspaceSymLinkEntries() =
-    allProtoDirs().joinToString("\n") { "|  - ${mangle(it)}" }
+    allProtoDirs()
+        .map { project.makeMangledRelativizedPathStr(it) }
+        .joinToString("\n") { "|  - $it" }
 
-private fun Task.allProtoDirs(): List<Path> =
-    (project.srcProtoDirs() + extractProtoDirs()).filter { project.anyProtos(it) }
+// Returns all directories that have may have proto files relevant to processing the project's proto files. This
+// includes any proto files that are simply references (includes) as well as those that will be processed (code
+// generation or validation).
+private fun Task.allProtoDirs(): List<File> =
+    (project.allProtoSourceSetDirs() + project.file(Paths.get(BUILD_EXTRACTED_INCLUDE_PROTOS_MAIN))).filter { anyProtos(it) }
 
-// NOTE: The hard coded extractProtoDirs are removed from the source set directories in order to fix issue
+// Returns the list of directories containing proto files defined in *this* project. The returned directories do *not*
+// include those that contain protos defined in dependencies and placed in the extracted-protos directory for codegen.
+// The returned directories *only* contain the proto files that should be processed by buf for operations like linting,
+// format checking, and breaking change detection.
+//
+// NOTE: We explicitly remove BUILD_EXTRACTED_PROTOS_MAIN from the list of source set directories in order to fix issue
 // https://github.com/bufbuild/buf-gradle-plugin/issues/132. Starting in version 0.9.2 of
 // protobuf-gradle-plugin, the "proto" source set srcDirs includes the outputs of the "extractedProtos" task, which
-// breaks this plugin when used with the protobuf-gradle-plugin and "protobuf" dependencies.
+// breaks this plugin when used with the protobuf-gradle-plugin and "protobuf" dependencies (which generates code for
+// any proto files within those dependencies).
 //
 // Protobuf-gradle-plugin change that introduced this behavior: https://github.com/google/protobuf-gradle-plugin/pull/637/
 // Line: https://github.com/google/protobuf-gradle-plugin/blob/9d2a328a0d577bf4439d3b482a953715b3a03027/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy#L425
-internal fun Project.srcProtoDirs() =
-    (the<SourceSetContainer>().flatMap { it.protoDirs(this) } + androidSrcProtoDirs())
-        .minus(extractProtoDirs())
+internal fun Project.projectDefinedProtoDirs() =
+    allProtoSourceSetDirs() - file(Paths.get(BUILD_EXTRACTED_PROTOS_MAIN))
 
-private fun Project.androidSrcProtoDirs() =
+// Returns deduplicated list of all proto source set directories.
+private fun Project.allProtoSourceSetDirs() = (projectProtoSourceSetDirs() + androidProtoSourceSetDirs()).toSet().toList()
+
+// Returns android proto source set directories that protobuf-gradle-plugin will codegen.
+private fun Project.androidProtoSourceSetDirs() =
     extensions.findByName("android")
         ?.let { baseExtension ->
             val prop = baseExtension::class.declaredMemberProperties.single { it.name == "sourceSets" }
@@ -126,21 +140,23 @@ private fun Project.androidSrcProtoDirs() =
             (prop as KProperty1<Any, Set<ExtensionAware>>).get(baseExtension)
         }
         .orEmpty()
-        .flatMap { it.protoDirs(this) }
+        .flatMap { it.projectProtoSourceSetDirs() }
 
-private fun ExtensionAware.protoDirs(project: Project) =
+// Returns all proto source set directories that the protobuf-gradle-plugin will codegen.
+private fun Project.projectProtoSourceSetDirs() = the<SourceSetContainer>().flatMap { it.projectProtoSourceSetDirs() }
+
+// Returns all directories within the "proto" source set of the receiver that actually contain proto file. This includes
+// directories explicitly added to the source set, as well as directories containing files from "protobuf" dependencies.
+private fun ExtensionAware.projectProtoSourceSetDirs() =
     extensions.getByName<SourceDirectorySet>("proto").srcDirs
-        .map { project.projectDir.toPath().relativize(it.toPath()) }
-        .filter { project.anyProtos(it) }
+        .filter { anyProtos(it) }
 
-private fun extractProtoDirs() =
-    listOf(
-        BUILD_EXTRACTED_INCLUDE_PROTOS_MAIN,
-        BUILD_EXTRACTED_PROTOS_MAIN
-    ).map(Paths::get)
+private fun Project.makeMangledRelativizedPathStr(file: File) =
+    mangle(projectDir.toPath().relativize(file.toPath()))
 
-private fun Project.anyProtos(path: Path) =
-    file(path).walkTopDown().any { it.extension == "proto" }
+// Indicates if the specified file contains any proto files.
+private fun anyProtos(file: File) =
+    file.walkTopDown().any { it.extension == "proto" }
 
 internal fun mangle(name: Path) =
     name.toString().replace("-", "--").replace(File.separator, "-")

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -108,11 +108,7 @@ private fun Task.allProtoDirs(): List<Path> =
     (project.srcProtoDirs() + extractProtoDirs()).filter { project.anyProtos(it) }
 
 internal fun Project.srcProtoDirs() =
-    (the<SourceSetContainer>().flatMap { it.protoDirs(this) } + androidSrcProtoDirs()).filter {
-        !extractProtoDirs().contains(
-            it
-        )
-    }
+    (the<SourceSetContainer>().flatMap { it.protoDirs(this) } + androidSrcProtoDirs()).minus(extractProtoDirs())
 
 private fun Project.androidSrcProtoDirs() =
     extensions.findByName("android")

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -109,8 +109,11 @@ private fun Task.workspaceSymLinkEntries() =
 // Returns all directories that have may have proto files relevant to processing the project's proto files. This
 // includes any proto files that are simply references (includes) as well as those that will be processed (code
 // generation or validation).
-private fun Task.allProtoDirs(): List<File> =
-    (project.allProtoSourceSetDirs() + project.file(Paths.get(BUILD_EXTRACTED_INCLUDE_PROTOS_MAIN))).filter { anyProtos(it) }
+private fun Task.allProtoDirs() =
+    project.allProtoSourceSetDirs()
+        .plus(project.file(Paths.get(BUILD_EXTRACTED_INCLUDE_PROTOS_MAIN)))
+        .filter { anyProtos(it) }
+        .toSet()
 
 // Returns the list of directories containing proto files defined in *this* project. The returned directories do *not*
 // include those that contain protos defined in dependencies and placed in the extracted-protos directory for codegen.
@@ -129,7 +132,8 @@ internal fun Project.projectDefinedProtoDirs() =
     allProtoSourceSetDirs() - file(Paths.get(BUILD_EXTRACTED_PROTOS_MAIN))
 
 // Returns deduplicated list of all proto source set directories.
-private fun Project.allProtoSourceSetDirs() = (projectProtoSourceSetDirs() + androidProtoSourceSetDirs()).toSet().toList()
+private fun Project.allProtoSourceSetDirs() =
+    projectProtoSourceSetDirs() + androidProtoSourceSetDirs()
 
 // Returns android proto source set directories that protobuf-gradle-plugin will codegen.
 private fun Project.androidProtoSourceSetDirs() =
@@ -141,16 +145,19 @@ private fun Project.androidProtoSourceSetDirs() =
         }
         .orEmpty()
         .flatMap { it.projectProtoSourceSetDirs() }
+        .toSet()
 
 // Returns all proto source set directories that the protobuf-gradle-plugin will codegen.
 private fun Project.projectProtoSourceSetDirs() =
     the<SourceSetContainer>().flatMap { it.projectProtoSourceSetDirs() }
+        .toSet()
 
 // Returns all directories within the "proto" source set of the receiver that actually contain proto files. This includes
 // directories explicitly added to the source set, as well as directories containing files from "protobuf" dependencies.
 private fun ExtensionAware.projectProtoSourceSetDirs() =
     extensions.getByName<SourceDirectorySet>("proto").srcDirs
         .filter { anyProtos(it) }
+        .toSet()
 
 internal fun Project.makeMangledRelativizedPathStr(file: File) =
     mangle(projectDir.toPath().relativize(file.toPath()))

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -158,7 +158,7 @@ internal fun Project.makeMangledRelativizedPathStr(file: File) =
 private fun anyProtos(file: File) =
     file.walkTopDown().any { it.extension == "proto" }
 
-internal fun mangle(name: Path) =
+private fun mangle(name: Path) =
     name.toString().replace("-", "--").replace(File.separator, "-")
 
 internal inline fun <reified T : Task> Project.registerBufTask(

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -151,7 +151,7 @@ private fun ExtensionAware.projectProtoSourceSetDirs() =
     extensions.getByName<SourceDirectorySet>("proto").srcDirs
         .filter { anyProtos(it) }
 
-private fun Project.makeMangledRelativizedPathStr(file: File) =
+internal fun Project.makeMangledRelativizedPathStr(file: File) =
     mangle(projectDir.toPath().relativize(file.toPath()))
 
 // Indicates if the specified file contains any proto files.

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -143,9 +143,10 @@ private fun Project.androidProtoSourceSetDirs() =
         .flatMap { it.projectProtoSourceSetDirs() }
 
 // Returns all proto source set directories that the protobuf-gradle-plugin will codegen.
-private fun Project.projectProtoSourceSetDirs() = the<SourceSetContainer>().flatMap { it.projectProtoSourceSetDirs() }
+private fun Project.projectProtoSourceSetDirs() =
+    the<SourceSetContainer>().flatMap { it.projectProtoSourceSetDirs() }
 
-// Returns all directories within the "proto" source set of the receiver that actually contain proto file. This includes
+// Returns all directories within the "proto" source set of the receiver that actually contain proto files. This includes
 // directories explicitly added to the source set, as well as directories containing files from "protobuf" dependencies.
 private fun ExtensionAware.projectProtoSourceSetDirs() =
     extensions.getByName<SourceDirectorySet>("proto").srcDirs
@@ -154,9 +155,9 @@ private fun ExtensionAware.projectProtoSourceSetDirs() =
 internal fun Project.makeMangledRelativizedPathStr(file: File) =
     mangle(projectDir.toPath().relativize(file.toPath()))
 
-// Indicates if the specified file contains any proto files.
-private fun anyProtos(file: File) =
-    file.walkTopDown().any { it.extension == "proto" }
+// Indicates if the specified directory contains any proto files.
+private fun anyProtos(directory: File) =
+    directory.walkTopDown().any { it.extension == "proto" }
 
 private fun mangle(name: Path) =
     name.toString().replace("-", "--").replace(File.separator, "-")

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -107,7 +107,7 @@ private fun Task.workspaceSymLinkEntries() =
 private fun Task.allProtoDirs(): List<Path> =
     (project.srcProtoDirs() + extractProtoDirs()).filter { project.anyProtos(it) }
 
-// NOTE: The hard coded extractProtoDirs are removed from the source set directories fixes issue
+// NOTE: The hard coded extractProtoDirs are removed from the source set directories to fix issue
 // https://github.com/bufbuild/buf-gradle-plugin/issues/132. Starting in version 0.9.2 of the
 // protobuf gradle plugin changed the directories in the proto srcDirs to include "extracted protos".
 //

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -107,11 +107,12 @@ private fun Task.workspaceSymLinkEntries() =
 private fun Task.allProtoDirs(): List<Path> =
     (project.srcProtoDirs() + extractProtoDirs()).filter { project.anyProtos(it) }
 
-// NOTE: The hard coded extractProtoDirs are removed from the source set directories to fix issue
-// https://github.com/bufbuild/buf-gradle-plugin/issues/132. Starting in version 0.9.2 of the
-// protobuf gradle plugin changed the directories in the proto srcDirs to include "extracted protos".
+// NOTE: The hard coded extractProtoDirs are removed from the source set directories in order to fix issue
+// https://github.com/bufbuild/buf-gradle-plugin/issues/132. Starting in version 0.9.2 of
+// protobuf-gradle-plugin, the "proto" source set srcDirs includes the outputs of the "extractedProtos" task, which
+// breaks this plugin when used with the protobuf-gradle-plugin and "protobuf" dependencies.
 //
-// Change that introduced this behavior: https://github.com/google/protobuf-gradle-plugin/pull/637/
+// Protobuf-gradle-plugin change that introduced this behavior: https://github.com/google/protobuf-gradle-plugin/pull/637/
 // Line: https://github.com/google/protobuf-gradle-plugin/blob/9d2a328a0d577bf4439d3b482a953715b3a03027/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy#L425
 internal fun Project.srcProtoDirs() =
     (the<SourceSetContainer>().flatMap { it.protoDirs(this) } + androidSrcProtoDirs())

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -108,7 +108,11 @@ private fun Task.allProtoDirs(): List<Path> =
     (project.srcProtoDirs() + extractProtoDirs()).filter { project.anyProtos(it) }
 
 internal fun Project.srcProtoDirs() =
-    the<SourceSetContainer>().flatMap { it.protoDirs(this) } + androidSrcProtoDirs()
+    (the<SourceSetContainer>().flatMap { it.protoDirs(this) } + androidSrcProtoDirs()).filter {
+        !extractProtoDirs().contains(
+            it
+        )
+    }
 
 private fun Project.androidSrcProtoDirs() =
     extensions.findByName("android")

--- a/src/test/kotlin/build/buf/gradle/AbstractBufIntegrationTest.kt
+++ b/src/test/kotlin/build/buf/gradle/AbstractBufIntegrationTest.kt
@@ -71,7 +71,7 @@ abstract class AbstractBufIntegrationTest : IntegrationTest {
             .withProjectDir(projectDir)
             .withPluginClasspath()
             .withArguments(
-                "-PprotobufGradleVersion=0.8.19",
+                "-PprotobufGradleVersion=0.9.3",
                 "-PprotobufVersion=3.21.7",
                 "-PkotlinVersion=1.7.20",
                 "-PandroidGradleVersion=7.3.0"


### PR DESCRIPTION
Addresses issue [132](https://github.com/bufbuild/buf-gradle-plugin/issues/132)

Fix buf tasks behavior with more recent versions of the `protobuf-gradle-plugin`. With version `0.9.3` (and possibly all `0.9.*` versions), the buf plugin tasks no longer work when `protobuf` dependencies are used (as described in the issue). This change filters the hard-coded "extracted" directories from the list of proto source directories set by the protobuf gradle plugin.

Tested by:
- Updating the test protobuf gradle plugin version to `0.9.3`.
- Verifying tests fail when using protobuf dependencies.
- Adding the extracted directory filter and verifying tests begin to pass.
