### PR TITLE
Update tests to use remote plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ An example, for Java code generation using the remote plugin:
 ``` yaml
 version: v1
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/java:<version>
+  - plugin: buf.build/protocolbuffers/java:<version>
     out: java
 ```
 

--- a/src/test/kotlin/build/buf/gradle/AbstractBufIntegrationTest.kt
+++ b/src/test/kotlin/build/buf/gradle/AbstractBufIntegrationTest.kt
@@ -72,7 +72,7 @@ abstract class AbstractBufIntegrationTest : IntegrationTest {
             .withPluginClasspath()
             .withArguments(
                 "-PprotobufGradleVersion=0.9.3",
-                "-PprotobufVersion=3.21.7",
+                "-PprotobufVersion=3.23.4",
                 "-PkotlinVersion=1.7.20",
                 "-PandroidGradleVersion=7.3.0"
             )

--- a/src/test/resources/GenerateTest/buf_generate_fails_when_a_specified_template_file_does_not_exist_but_a_default_one_does/buf.gen.yaml
+++ b/src/test/resources/GenerateTest/buf_generate_fails_when_a_specified_template_file_does_not_exist_but_a_default_one_does/buf.gen.yaml
@@ -1,4 +1,4 @@
 version: v1
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/java:v3.20.0-1
+  - plugin: buf.build/protocolbuffers/java:v23.4
     out: java

--- a/src/test/resources/GenerateTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/buf.gen.yaml
+++ b/src/test/resources/GenerateTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/buf.gen.yaml
@@ -1,4 +1,4 @@
 version: v1
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/java:v3.20.0-1
+  - plugin: buf.build/protocolbuffers/java:v23.4
     out: java

--- a/src/test/resources/GenerateTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/subdir/buf.gen.yaml
+++ b/src/test/resources/GenerateTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/subdir/buf.gen.yaml
@@ -1,4 +1,4 @@
 version: v1
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/java:v3.20.0-1
+  - plugin: buf.build/protocolbuffers/java:v23.4
     out: java

--- a/src/test/resources/GenerateTest/buf_generate_with_buf_gen_template_file_override/subdir/buf.gen.yaml
+++ b/src/test/resources/GenerateTest/buf_generate_with_buf_gen_template_file_override/subdir/buf.gen.yaml
@@ -1,4 +1,4 @@
 version: v1
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/java:v3.20.0-1
+  - plugin: buf.build/protocolbuffers/java:v23.4
     out: java

--- a/src/test/resources/GenerateTest/generate_java/buf.gen.yaml
+++ b/src/test/resources/GenerateTest/generate_java/buf.gen.yaml
@@ -1,4 +1,4 @@
 version: v1
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/java:v3.20.0-1
+  - plugin: buf.build/protocolbuffers/java:v23.4
     out: java

--- a/src/test/resources/GenerateTest/generate_java_with_include_imports/buf.gen.yaml
+++ b/src/test/resources/GenerateTest/generate_java_with_include_imports/buf.gen.yaml
@@ -1,4 +1,4 @@
 version: v1
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/java:v3.20.0-1
+  - plugin: buf.build/protocolbuffers/java:v23.4
     out: java

--- a/src/test/resources/GenerateTest/generate_java_with_kotlin_dsl/buf.gen.yaml
+++ b/src/test/resources/GenerateTest/generate_java_with_kotlin_dsl/buf.gen.yaml
@@ -1,4 +1,4 @@
 version: v1
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/java:v3.20.0-1
+  - plugin: buf.build/protocolbuffers/java:v23.4
     out: java

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_when_a_specified_template_file_does_not_exist_but_a_default_one_does/buf.gen.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_when_a_specified_template_file_does_not_exist_but_a_default_one_does/buf.gen.yaml
@@ -1,4 +1,4 @@
 version: v1
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/java:v3.20.0-1
+  - plugin: buf.build/protocolbuffers/java:v23.4
     out: java

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/buf.gen.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/buf.gen.yaml
@@ -1,4 +1,4 @@
 version: v1
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/java:v3.20.0-1
+  - plugin: buf.build/protocolbuffers/java:v23.4
     out: java

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/subdir/buf.gen.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/subdir/buf.gen.yaml
@@ -1,4 +1,4 @@
 version: v1
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/java:v3.20.0-1
+  - plugin: buf.build/protocolbuffers/java:v23.4
     out: java

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_buf_gen_template_file_override/subdir/buf.gen.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_buf_gen_template_file_override/subdir/buf.gen.yaml
@@ -1,4 +1,4 @@
 version: v1
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/java:v3.20.0-1
+  - plugin: buf.build/protocolbuffers/java:v23.4
     out: java

--- a/src/test/resources/GenerateWithWorkspaceTest/generate_java/buf.gen.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/generate_java/buf.gen.yaml
@@ -1,4 +1,4 @@
 version: v1
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/java:v3.20.0-1
+  - plugin: buf.build/protocolbuffers/java:v23.4
     out: java

--- a/src/test/resources/GenerateWithWorkspaceTest/generate_java_with_include_imports/buf.gen.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/generate_java_with_include_imports/buf.gen.yaml
@@ -1,4 +1,4 @@
 version: v1
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/java:v3.20.0-1
+  - plugin: buf.build/protocolbuffers/java:v23.4
     out: java

--- a/src/test/resources/GenerateWithWorkspaceTest/generate_java_with_kotlin_dsl/buf.gen.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/generate_java_with_kotlin_dsl/buf.gen.yaml
@@ -1,4 +1,4 @@
 version: v1
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/java:v3.20.0-1
+  - plugin: buf.build/protocolbuffers/java:v23.4
     out: java


### PR DESCRIPTION
Remove references to the remote generation alpha and switch all tests to use remote plugins.
