### PR TITLE
Delay configuration of buf binary configuration until after the tool version is resolvable from the extension

### DIFF
--- a/src/main/kotlin/build/buf/gradle/BufPlugin.kt
+++ b/src/main/kotlin/build/buf/gradle/BufPlugin.kt
@@ -35,13 +35,13 @@ class BufPlugin : Plugin<Project> {
     }
 
     private fun Project.configureBuf() {
-        configureBufDependency()
         configureLint()
         configureFormat()
         configureBuild()
         configureGenerate()
 
         afterEvaluate {
+            configureBufDependency()
             getArtifactDetails()?.let {
                 if (publishSchema()) {
                     configureImagePublication(it)

--- a/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
@@ -27,7 +27,7 @@ internal fun Task.execBufInSpecificDirectory(
 internal fun Task.execBufInSpecificDirectory(
     bufCommand: String,
     extraArgs: Iterable<String>,
-    customErrorMessage: ((String) -> String),
+    customErrorMessage: (String) -> String,
 ) {
     execBufInSpecificDirectory(listOf(bufCommand), extraArgs, customErrorMessage)
 }

--- a/src/test/kotlin/build/buf/gradle/AbstractBufIntegrationTest.kt
+++ b/src/test/kotlin/build/buf/gradle/AbstractBufIntegrationTest.kt
@@ -39,9 +39,6 @@ abstract class AbstractBufIntegrationTest : IntegrationTest {
         File(projectDir, "settings.gradle").writeText("rootProject.name = 'testing'")
         File(projectDir, "gradle.properties").writeText("org.gradle.jvmargs=-Xmx5g")
 
-        // TODO: The test name is dependent on the directory name.
-        // There is a change to sanitize the directory names to be compatible
-        // with Buf's license-header tool.
         val testName = testInfo.testMethod.get().name
             .replace(",", "")
             .replace("--", "")

--- a/src/test/kotlin/build/buf/gradle/BufVersionTest.kt
+++ b/src/test/kotlin/build/buf/gradle/BufVersionTest.kt
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test
 class BufVersionTest : AbstractBufIntegrationTest() {
     @Test
     fun `buf version can be specified by the extension`() {
-        val result = gradleRunner().withArguments("printBufVersion").build()
+        val result = gradleRunner().withArguments("printBufVersion", "-PbufVersion=asdf").build()
 
         val versionLine = result.output.lines().single { it.startsWith("Resolved") }
 

--- a/src/test/kotlin/build/buf/gradle/BufVersionTest.kt
+++ b/src/test/kotlin/build/buf/gradle/BufVersionTest.kt
@@ -1,0 +1,29 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buf.gradle
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class BufVersionTest : AbstractBufIntegrationTest() {
+    @Test
+    fun `buf version can be specified by the extension`() {
+        val result = gradleRunner().withArguments("printBufVersion").build()
+
+        val versionLine = result.output.lines().single { it.startsWith("Resolved") }
+
+        assertThat(versionLine).isEqualTo("Resolved Buf tool version: asdf")
+    }
+}

--- a/src/test/resources/BufVersionTest/buf_version_can_be_specified_by_the_extension/build.gradle
+++ b/src/test/resources/BufVersionTest/buf_version_can_be_specified_by_the_extension/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 buf {
-    toolVersion = "asdf"
+    toolVersion = project.properties.get("bufVersion")
 }
 
 tasks.register("printBufVersion") {
-    def bufConfiguration = project.configurations.named("bufTool").get()
+    def bufConfiguration = project.configurations.named(BUF_BINARY_CONFIGURATION_NAME).get()
     bufConfiguration.dependencies.forEach {
         logger.quiet("Resolved Buf tool version: ${it.version}")
     }

--- a/src/test/resources/BufVersionTest/buf_version_can_be_specified_by_the_extension/build.gradle
+++ b/src/test/resources/BufVersionTest/buf_version_can_be_specified_by_the_extension/build.gradle
@@ -1,0 +1,16 @@
+import static build.buf.gradle.BufSupportKt.BUF_BINARY_CONFIGURATION_NAME
+
+plugins {
+    id "build.buf"
+}
+
+buf {
+    toolVersion = "asdf"
+}
+
+tasks.register("printBufVersion") {
+    def bufConfiguration = project.configurations.named("bufTool").get()
+    bufConfiguration.dependencies.forEach {
+        logger.quiet("Resolved Buf tool version: ${it.version}")
+    }
+}

--- a/src/test/resources/BufVersionTest/buf_version_can_be_specified_by_the_extension/build.gradle
+++ b/src/test/resources/BufVersionTest/buf_version_can_be_specified_by_the_extension/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 buf {
-    toolVersion = project.properties.get("bufVersion")
+    toolVersion = "$bufVersion"
 }
 
 tasks.register("printBufVersion") {


### PR DESCRIPTION
See the (formerly) failing test - `configureBufDependency` grabs the `toolVersion` from the extension at plugin application time today, but this needs to be done after project evaluation in order to get the configured version.

