### PR TITLE
Fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ running tests, and contributing to the repository are available in our
 ## Ecosystem
 
 * [connect-kotlin]: Kotlin clients for idiomatic gRPC & Connect RPC
-* [connect-web]: TypeScript clients for web browsers
+* [connect-es]: TypeScript clients for web browsers
 * [connect-go]: Service handlers and clients for GoLang
 * [Buf Studio][buf-studio]: Web UI for ad-hoc RPCs
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ running tests, and contributing to the repository are available in our
 ## Ecosystem
 
 * [connect-kotlin]: Kotlin clients for idiomatic gRPC & Connect RPC
-* [connect-es]: TypeScript clients for web browsers
+* [connect-es]: Type-safe APIs with Protobuf and TypeScript.
 * [connect-go]: Service handlers and clients for GoLang
 * [Buf Studio][buf-studio]: Web UI for ad-hoc RPCs
 


### PR DESCRIPTION
This fixes a missed link on the README. It also updates the description to reflect that Connect-ES is more than just clients.