### PR TITLE
Add test codifying behavior when two modules reuse the same extension number

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 buildscript { repositories { gradlePluginPortal() } }
 
 plugins {
-    id("net.vivin.gradle-semantic-build-versioning") version "4.0.0"
+    id("io.alcide.gradle-semantic-build-versioning") version "4.2.2"
 }
 
 rootProject.name = "buf-gradle-plugin"

--- a/src/test/kotlin/build/buf/gradle/AbstractBuildTest.kt
+++ b/src/test/kotlin/build/buf/gradle/AbstractBuildTest.kt
@@ -49,6 +49,15 @@ abstract class AbstractBuildTest : AbstractBufIntegrationTest() {
         assertImageGeneration()
     }
 
+    @Test
+    fun `build an image reusing an extension number`() {
+        val result = buildRunner().buildAndFail()
+        assertThat(result.output).contains(
+            "buf/test/v1/test.proto:23:14:extension with tag 1072 for message google.protobuf.MessageOptions already " +
+                "defined at validate/validate.proto:17:29",
+        )
+    }
+
     private fun assertImageGeneration() {
         assertThat(buildRunner().build().task(":$BUF_BUILD_TASK_NAME")?.outcome).isEqualTo(SUCCESS)
         val image = Paths.get(projectDir.path, "build", "bufbuild", "image.json").toFile().readText()

--- a/src/test/kotlin/build/buf/gradle/AbstractBuildTest.kt
+++ b/src/test/kotlin/build/buf/gradle/AbstractBuildTest.kt
@@ -17,6 +17,7 @@ package build.buf.gradle
 import com.google.common.truth.Truth.assertThat
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.junit.jupiter.api.Test
+import java.io.File
 import java.nio.file.Paths
 
 abstract class AbstractBuildTest : AbstractBufIntegrationTest() {
@@ -52,9 +53,10 @@ abstract class AbstractBuildTest : AbstractBufIntegrationTest() {
     @Test
     fun `build an image reusing an extension number`() {
         val result = buildRunner().buildAndFail()
+        val source = listOf("buf", "test", "v1", "test.proto").joinToString(File.separator)
         assertThat(result.output).contains(
-            "buf/test/v1/test.proto:23:14:extension with tag 1072 for message google.protobuf.MessageOptions already " +
-                "defined at validate/validate.proto:17:29",
+            "$source:23:14:extension with tag 1072 for message google.protobuf.MessageOptions already defined at " +
+                "validate/validate.proto:17:29",
         )
     }
 

--- a/src/test/resources/BuildTest/build_an_image_reusing_an_extension_number/buf.lock
+++ b/src/test/resources/BuildTest/build_an_image_reusing_an_extension_number/buf.lock
@@ -1,0 +1,6 @@
+version: v1
+deps:
+  - remote: buf.build
+    owner: envoyproxy
+    repository: protoc-gen-validate
+    commit: 71881f09a0c5420a9545a07987a86728

--- a/src/test/resources/BuildTest/build_an_image_reusing_an_extension_number/buf.yaml
+++ b/src/test/resources/BuildTest/build_an_image_reusing_an_extension_number/buf.yaml
@@ -1,0 +1,3 @@
+version: v1
+deps:
+  - buf.build/envoyproxy/protoc-gen-validate

--- a/src/test/resources/BuildTest/build_an_image_reusing_an_extension_number/buf/test/v1/test.proto
+++ b/src/test/resources/BuildTest/build_an_image_reusing_an_extension_number/buf/test/v1/test.proto
@@ -1,0 +1,24 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.test.v1;
+
+import "google/protobuf/descriptor.proto";
+import "validate/validate.proto";
+
+extend google.protobuf.MessageOptions {
+  bool foo = 1072;
+}

--- a/src/test/resources/BuildTest/build_an_image_reusing_an_extension_number/build.gradle
+++ b/src/test/resources/BuildTest/build_an_image_reusing_an_extension_number/build.gradle
@@ -1,0 +1,8 @@
+plugins {
+  id 'java'
+  id 'build.buf'
+}
+
+repositories {
+  mavenCentral()
+}

--- a/src/test/resources/BuildWithProtobufGradleTest/build_an_image_reusing_an_extension_number/build.gradle
+++ b/src/test/resources/BuildWithProtobufGradleTest/build_an_image_reusing_an_extension_number/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+  id 'java'
+  id 'com.google.protobuf' version "$protobufGradleVersion"
+  id 'build.buf'
+}
+
+repositories {
+  mavenCentral()
+}
+
+protobuf {
+  protoc {
+    artifact = "com.google.protobuf:protoc:$protobufVersion"
+  }
+}
+
+dependencies {
+  protobuf 'io.envoyproxy.controlplane:api:1.0.41'
+}

--- a/src/test/resources/BuildWithProtobufGradleTest/build_an_image_reusing_an_extension_number/src/main/proto/buf/test/v1/test.proto
+++ b/src/test/resources/BuildWithProtobufGradleTest/build_an_image_reusing_an_extension_number/src/main/proto/buf/test/v1/test.proto
@@ -1,0 +1,24 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.test.v1;
+
+import "google/protobuf/descriptor.proto";
+import "validate/validate.proto";
+
+extend google.protobuf.MessageOptions {
+  bool foo = 1072;
+}

--- a/src/test/resources/BuildWithWorkspaceTest/build_an_image_reusing_an_extension_number/buf.work.yaml
+++ b/src/test/resources/BuildWithWorkspaceTest/build_an_image_reusing_an_extension_number/buf.work.yaml
@@ -1,0 +1,3 @@
+version: v1
+directories:
+  - workspace

--- a/src/test/resources/BuildWithWorkspaceTest/build_an_image_reusing_an_extension_number/build.gradle
+++ b/src/test/resources/BuildWithWorkspaceTest/build_an_image_reusing_an_extension_number/build.gradle
@@ -1,0 +1,8 @@
+plugins {
+  id 'java'
+  id 'build.buf'
+}
+
+repositories {
+  mavenCentral()
+}

--- a/src/test/resources/BuildWithWorkspaceTest/build_an_image_reusing_an_extension_number/workspace/buf.lock
+++ b/src/test/resources/BuildWithWorkspaceTest/build_an_image_reusing_an_extension_number/workspace/buf.lock
@@ -1,0 +1,6 @@
+version: v1
+deps:
+  - remote: buf.build
+    owner: envoyproxy
+    repository: protoc-gen-validate
+    commit: 71881f09a0c5420a9545a07987a86728

--- a/src/test/resources/BuildWithWorkspaceTest/build_an_image_reusing_an_extension_number/workspace/buf.yaml
+++ b/src/test/resources/BuildWithWorkspaceTest/build_an_image_reusing_an_extension_number/workspace/buf.yaml
@@ -1,0 +1,3 @@
+version: v1
+deps:
+  - buf.build/envoyproxy/protoc-gen-validate

--- a/src/test/resources/BuildWithWorkspaceTest/build_an_image_reusing_an_extension_number/workspace/buf/test/v1/test.proto
+++ b/src/test/resources/BuildWithWorkspaceTest/build_an_image_reusing_an_extension_number/workspace/buf/test/v1/test.proto
@@ -1,0 +1,24 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.test.v1;
+
+import "google/protobuf/descriptor.proto";
+import "validate/validate.proto";
+
+extend google.protobuf.MessageOptions {
+  bool foo = 1072;
+}


### PR DESCRIPTION
Beginning the process of addressing https://github.com/envoyproxy/java-control-plane/issues/296.

The plugin should be able to be configured to ignore these conflicts since the user is not in control of the bad actor dependency.

The failing tests are due to user-level failure, but in principle (and this is what happened) one may have dependencies that conflict and there's nothing you can do.