### PR TITLE
Support configuration cache

### DIFF
--- a/src/main/kotlin/build/buf/gradle/AbstractBufExecTask.kt
+++ b/src/main/kotlin/build/buf/gradle/AbstractBufExecTask.kt
@@ -18,6 +18,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import java.io.File
 
 /**
  * A task executing buf executable as part of its operation.
@@ -26,6 +27,14 @@ abstract class AbstractBufExecTask : AbstractBufTask() {
     /** The buf executable. */
     @get:InputFiles
     internal abstract val bufExecutable: ConfigurableFileCollection
+
+    /**
+     * The directory in which buf is executed.
+     * The actual real input files in this directory have to be tracked per command separately,
+     * so it is just an @Input, not @InputDirectory.
+     */
+    @get:Input
+    internal abstract val workingDir: Property<File>
 
     /** Whether the project has protobuf plugin enabled. */
     @get:Input

--- a/src/main/kotlin/build/buf/gradle/AbstractBufExecTask.kt
+++ b/src/main/kotlin/build/buf/gradle/AbstractBufExecTask.kt
@@ -14,7 +14,14 @@
 
 package build.buf.gradle
 
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.InputFiles
+
 /**
  * A task executing buf executable as part of its operation.
  */
-abstract class AbstractBufExecTask : AbstractBufTask()
+abstract class AbstractBufExecTask : AbstractBufTask() {
+    /** The buf executable. */
+    @get:InputFiles
+    internal abstract val bufExecutable: ConfigurableFileCollection
+}

--- a/src/main/kotlin/build/buf/gradle/AbstractBufExecTask.kt
+++ b/src/main/kotlin/build/buf/gradle/AbstractBufExecTask.kt
@@ -15,6 +15,8 @@
 package build.buf.gradle
 
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 
 /**
@@ -24,4 +26,8 @@ abstract class AbstractBufExecTask : AbstractBufTask() {
     /** The buf executable. */
     @get:InputFiles
     internal abstract val bufExecutable: ConfigurableFileCollection
+
+    /** Whether the project has buf workspace or not. */
+    @get:Input
+    internal abstract val hasWorkspace: Property<Boolean>
 }

--- a/src/main/kotlin/build/buf/gradle/AbstractBufExecTask.kt
+++ b/src/main/kotlin/build/buf/gradle/AbstractBufExecTask.kt
@@ -31,6 +31,10 @@ abstract class AbstractBufExecTask : AbstractBufTask() {
     @get:Input
     internal abstract val hasProtobufGradlePlugin: Property<Boolean>
 
+    /** Directories possibly containing input .proto files. */
+    @get:InputFiles
+    internal abstract val candidateProtoDirs: ConfigurableFileCollection
+
     /** Whether the project has buf workspace or not. */
     @get:Input
     internal abstract val hasWorkspace: Property<Boolean>

--- a/src/main/kotlin/build/buf/gradle/AbstractBufExecTask.kt
+++ b/src/main/kotlin/build/buf/gradle/AbstractBufExecTask.kt
@@ -1,4 +1,4 @@
-// Copyright 2023 Buf Technologies, Inc.
+// Copyright 2024 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,11 +14,9 @@
 
 package build.buf.gradle
 
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.DefaultTask
 
-abstract class BuildTask : AbstractBufExecTask() {
-    @TaskAction
-    fun bufBuild() {
-        execBuf("build", "--output", bufBuildPublicationFile)
-    }
-}
+/**
+ * A task executing buf executable as part of its operation.
+ */
+abstract class AbstractBufExecTask : DefaultTask()

--- a/src/main/kotlin/build/buf/gradle/AbstractBufExecTask.kt
+++ b/src/main/kotlin/build/buf/gradle/AbstractBufExecTask.kt
@@ -27,6 +27,10 @@ abstract class AbstractBufExecTask : AbstractBufTask() {
     @get:InputFiles
     internal abstract val bufExecutable: ConfigurableFileCollection
 
+    /** Whether the project has protobuf plugin enabled. */
+    @get:Input
+    internal abstract val hasProtobufGradlePlugin: Property<Boolean>
+
     /** Whether the project has buf workspace or not. */
     @get:Input
     internal abstract val hasWorkspace: Property<Boolean>

--- a/src/main/kotlin/build/buf/gradle/AbstractBufTask.kt
+++ b/src/main/kotlin/build/buf/gradle/AbstractBufTask.kt
@@ -15,5 +15,15 @@
 package build.buf.gradle
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import java.io.File
 
-abstract class AbstractBufTask : DefaultTask()
+abstract class AbstractBufTask : DefaultTask() {
+    /**
+     * This property has to be set to project directory. It is only used for relativization of paths,
+     * so it is just an @Input, not @InputDirectory.
+     */
+    @get:Input
+    internal abstract val projectDir: Property<File>
+}

--- a/src/main/kotlin/build/buf/gradle/AbstractBufTask.kt
+++ b/src/main/kotlin/build/buf/gradle/AbstractBufTask.kt
@@ -14,7 +14,6 @@
 
 package build.buf.gradle
 
-/**
- * A task executing buf executable as part of its operation.
- */
-abstract class AbstractBufExecTask : AbstractBufTask()
+import org.gradle.api.DefaultTask
+
+abstract class AbstractBufTask : DefaultTask()

--- a/src/main/kotlin/build/buf/gradle/BreakingConfiguration.kt
+++ b/src/main/kotlin/build/buf/gradle/BreakingConfiguration.kt
@@ -50,7 +50,7 @@ private fun Project.addSchemaDependency(artifactDetails: ArtifactDetails) {
 }
 
 private fun Project.configureBreakingTask() {
-    registerBufTask<BreakingTask>(BUF_BREAKING_TASK_NAME) {
+    registerBufExecTask<BreakingTask>(BUF_BREAKING_TASK_NAME) {
         group = VERIFICATION_GROUP
         description = "Checks that Protobuf API definitions are backwards-compatible with previous versions."
 

--- a/src/main/kotlin/build/buf/gradle/BreakingConfiguration.kt
+++ b/src/main/kotlin/build/buf/gradle/BreakingConfiguration.kt
@@ -55,5 +55,13 @@ private fun Project.configureBreakingTask() {
         description = "Checks that Protobuf API definitions are backwards-compatible with previous versions."
 
         dependsOn(BUF_BUILD_TASK_NAME)
+
+        if (project.bufV1SyntaxOnly()) {
+            v1SyntaxOnly.set(true)
+            publicationFile.set(project.bufBuildPublicationFile)
+        } else {
+            v1SyntaxOnly.set(false)
+        }
+        configFile.set(singleFileFromConfiguration(BUF_BREAKING_CONFIGURATION_NAME))
     }
 }

--- a/src/main/kotlin/build/buf/gradle/BreakingTask.kt
+++ b/src/main/kotlin/build/buf/gradle/BreakingTask.kt
@@ -14,18 +14,35 @@
 
 package build.buf.gradle
 
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
+import java.io.File
 
 abstract class BreakingTask : AbstractBufExecTask() {
+    @get:Input
+    internal abstract val v1SyntaxOnly: Property<Boolean>
+
+    /** The input publication file. */
+    @get:InputFile
+    @get:Optional
+    internal abstract val publicationFile: Property<File>
+
+    /** The input breaking config file. */
+    @get:InputFile
+    internal abstract val configFile: Property<File>
+
     @TaskAction
     fun bufBreaking() {
         val args = mutableListOf<Any>()
         args.add("breaking")
-        if (project.bufV1SyntaxOnly()) {
-            args.add(bufBuildPublicationFile)
+        if (v1SyntaxOnly.get()) {
+            args.add(publicationFile.get())
         }
         args.add("--against")
-        args.add(singleFileFromConfiguration(BUF_BREAKING_CONFIGURATION_NAME))
+        args.add(configFile.get())
         execBuf(*args.toTypedArray()) {
             """
                 |Some Protobuf files had breaking changes:

--- a/src/main/kotlin/build/buf/gradle/BreakingTask.kt
+++ b/src/main/kotlin/build/buf/gradle/BreakingTask.kt
@@ -14,10 +14,9 @@
 
 package build.buf.gradle
 
-import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
-abstract class BreakingTask : DefaultTask() {
+abstract class BreakingTask : AbstractBufExecTask() {
     @TaskAction
     fun bufBreaking() {
         val args = mutableListOf<Any>()

--- a/src/main/kotlin/build/buf/gradle/BufPlugin.kt
+++ b/src/main/kotlin/build/buf/gradle/BufPlugin.kt
@@ -35,6 +35,7 @@ class BufPlugin : Plugin<Project> {
     }
 
     private fun Project.configureBuf() {
+        createBufBinaryDependencyConfiguration()
         configureLint()
         configureFormat()
         configureBuild()

--- a/src/main/kotlin/build/buf/gradle/BufSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/BufSupport.kt
@@ -15,9 +15,14 @@
 package build.buf.gradle
 
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
 import java.nio.charset.StandardCharsets
 
 const val BUF_BINARY_CONFIGURATION_NAME = "bufTool"
+
+internal fun Project.createBufBinaryDependencyConfiguration() {
+    configurations.create(BUF_BINARY_CONFIGURATION_NAME)
+}
 
 internal fun Project.configureBufDependency() {
     val os = System.getProperty("os.name").lowercase()
@@ -38,16 +43,18 @@ internal fun Project.configureBufDependency() {
 
     val extension = getExtension()
 
-    createConfigurationWithDependency(
-        BUF_BINARY_CONFIGURATION_NAME,
-        mapOf(
-            "group" to "build.buf",
-            "name" to "buf",
-            "version" to extension.toolVersion,
-            "classifier" to "$osPart-$archPart",
-            "ext" to "exe",
-        ),
-    )
+    dependencies {
+        add(
+            BUF_BINARY_CONFIGURATION_NAME,
+            mapOf(
+                "group" to "build.buf",
+                "name" to "buf",
+                "version" to extension.toolVersion,
+                "classifier" to "$osPart-$archPart",
+                "ext" to "exe",
+            ),
+        )
+    }
 }
 
 internal fun AbstractBufExecTask.execBuf(
@@ -62,7 +69,7 @@ internal fun AbstractBufExecTask.execBuf(
     customErrorMessage: ((String) -> String)? = null,
 ) {
     with(project) {
-        val executable = singleFileFromConfiguration(BUF_BINARY_CONFIGURATION_NAME)
+        val executable = bufExecutable.singleFile
 
         if (!executable.canExecute()) {
             executable.setExecutable(true)

--- a/src/main/kotlin/build/buf/gradle/BufSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/BufSupport.kt
@@ -76,7 +76,7 @@ internal fun AbstractBufExecTask.execBuf(
         }
 
         val workingDir =
-            if (hasProtobufGradlePlugin()) {
+            if (hasProtobufGradlePlugin.get()) {
                 bufbuildDir
             } else {
                 projectDir

--- a/src/main/kotlin/build/buf/gradle/BufSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/BufSupport.kt
@@ -94,3 +94,10 @@ internal fun AbstractBufExecTask.execBuf(
         }
     }
 }
+
+internal fun AbstractBufExecTask.obtainDefaultProtoFileSet() =
+    project.fileTree(workingDir.get()) {
+        include("**/*.proto")
+        // not to interfere with random plugins producing output to build dir
+        exclude("build")
+    }

--- a/src/main/kotlin/build/buf/gradle/BufSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/BufSupport.kt
@@ -68,31 +68,29 @@ internal fun AbstractBufExecTask.execBuf(
     args: Iterable<Any>,
     customErrorMessage: ((String) -> String)? = null,
 ) {
-    with(project) {
-        val executable = bufExecutable.singleFile
+    val executable = bufExecutable.singleFile
 
-        if (!executable.canExecute()) {
-            executable.setExecutable(true)
-        }
+    if (!executable.canExecute()) {
+        executable.setExecutable(true)
+    }
 
-        val processArgs = listOf(executable.absolutePath) + args
-        val workingDirValue = workingDir.get()
+    val processArgs = listOf(executable.absolutePath) + args
+    val workingDirValue = workingDir.get()
 
-        logger.info("Running buf from $workingDirValue: `buf ${args.joinToString(" ")}`")
-        val result = ProcessRunner().use { it.shell(workingDirValue, processArgs) }
+    logger.info("Running buf from $workingDirValue: `buf ${args.joinToString(" ")}`")
+    val result = ProcessRunner().use { it.shell(workingDirValue, processArgs) }
 
-        if (result.exitCode != 0) {
-            if (customErrorMessage != null) {
-                val stdOut = result.stdOut.toString(StandardCharsets.UTF_8)
-                val stdErr = result.stdErr.toString(StandardCharsets.UTF_8)
-                val ex = IllegalStateException(customErrorMessage(stdOut))
-                if (stdErr.isNotEmpty()) {
-                    ex.addSuppressed(IllegalStateException(result.toString()))
-                }
-                throw ex
-            } else {
-                error(result.toString())
+    if (result.exitCode != 0) {
+        if (customErrorMessage != null) {
+            val stdOut = result.stdOut.toString(StandardCharsets.UTF_8)
+            val stdErr = result.stdErr.toString(StandardCharsets.UTF_8)
+            val ex = IllegalStateException(customErrorMessage(stdOut))
+            if (stdErr.isNotEmpty()) {
+                ex.addSuppressed(IllegalStateException(result.toString()))
             }
+            throw ex
+        } else {
+            error(result.toString())
         }
     }
 }

--- a/src/main/kotlin/build/buf/gradle/BufSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/BufSupport.kt
@@ -75,17 +75,11 @@ internal fun AbstractBufExecTask.execBuf(
             executable.setExecutable(true)
         }
 
-        val workingDir =
-            if (hasProtobufGradlePlugin.get()) {
-                bufbuildDir
-            } else {
-                projectDir
-            }
-
         val processArgs = listOf(executable.absolutePath) + args
+        val workingDirValue = workingDir.get()
 
-        logger.info("Running buf from $workingDir: `buf ${args.joinToString(" ")}`")
-        val result = ProcessRunner().use { it.shell(workingDir, processArgs) }
+        logger.info("Running buf from $workingDirValue: `buf ${args.joinToString(" ")}`")
+        val result = ProcessRunner().use { it.shell(workingDirValue, processArgs) }
 
         if (result.exitCode != 0) {
             if (customErrorMessage != null) {

--- a/src/main/kotlin/build/buf/gradle/BufSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/BufSupport.kt
@@ -15,7 +15,6 @@
 package build.buf.gradle
 
 import org.gradle.api.Project
-import org.gradle.api.Task
 import java.nio.charset.StandardCharsets
 
 const val BUF_BINARY_CONFIGURATION_NAME = "bufTool"
@@ -51,14 +50,14 @@ internal fun Project.configureBufDependency() {
     )
 }
 
-internal fun Task.execBuf(
+internal fun AbstractBufExecTask.execBuf(
     vararg args: Any,
     customErrorMessage: ((String) -> String)? = null,
 ) {
     execBuf(args.asList(), customErrorMessage)
 }
 
-internal fun Task.execBuf(
+internal fun AbstractBufExecTask.execBuf(
     args: Iterable<Any>,
     customErrorMessage: ((String) -> String)? = null,
 ) {

--- a/src/main/kotlin/build/buf/gradle/BuildConfiguration.kt
+++ b/src/main/kotlin/build/buf/gradle/BuildConfiguration.kt
@@ -15,7 +15,6 @@
 package build.buf.gradle
 
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.kotlin.dsl.create
@@ -34,10 +33,10 @@ internal fun Project.configureBuild() {
 
         if (hasProtobufGradlePlugin()) {
             dependsOn(COPY_BUF_CONFIG_TASK_NAME)
-        } else {
-            // Called already during workspace configuration if the protobuf-gradle-plugin has been applied
-            createsOutput()
         }
+
+        inputFiles.setFrom(obtainDefaultProtoFileSet())
+        publicationFile.set(project.bufBuildPublicationFile)
     }
 }
 
@@ -66,6 +65,3 @@ private val Project.bufBuildPublicationFileExtension
 
 internal val Project.bufBuildPublicationFile
     get() = File(bufbuildDir, "$BUF_BUILD_PUBLICATION_FILE_BASE_NAME.$bufBuildPublicationFileExtension")
-
-internal val Task.bufBuildPublicationFile
-    get() = project.bufBuildPublicationFile

--- a/src/main/kotlin/build/buf/gradle/BuildConfiguration.kt
+++ b/src/main/kotlin/build/buf/gradle/BuildConfiguration.kt
@@ -64,7 +64,7 @@ private val Project.bufBuildPublicationFileExtension
             deets.imageFormat.formatName + deets.compressionFormat?.let { ".${it.ext}" }.orEmpty()
         }
 
-private val Project.bufBuildPublicationFile
+internal val Project.bufBuildPublicationFile
     get() = File(bufbuildDir, "$BUF_BUILD_PUBLICATION_FILE_BASE_NAME.$bufBuildPublicationFileExtension")
 
 internal val Task.bufBuildPublicationFile

--- a/src/main/kotlin/build/buf/gradle/BuildConfiguration.kt
+++ b/src/main/kotlin/build/buf/gradle/BuildConfiguration.kt
@@ -28,7 +28,7 @@ private const val BUF_BUILD_PUBLICATION_FILE_BASE_NAME = "image"
 const val BUF_IMAGE_PUBLICATION_NAME = "bufImagePublication"
 
 internal fun Project.configureBuild() {
-    registerBufTask<BuildTask>(BUF_BUILD_TASK_NAME) {
+    registerBufExecTask<BuildTask>(BUF_BUILD_TASK_NAME) {
         group = BUILD_GROUP
         description = "Builds a Buf image from a Protobuf schema."
 

--- a/src/main/kotlin/build/buf/gradle/BuildTask.kt
+++ b/src/main/kotlin/build/buf/gradle/BuildTask.kt
@@ -14,11 +14,24 @@
 
 package build.buf.gradle
 
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import java.io.File
 
 abstract class BuildTask : AbstractBufExecTask() {
+    /** The input files. */
+    @get:InputFiles
+    internal abstract val inputFiles: ConfigurableFileCollection
+
+    /** The output publication file. */
+    @get:OutputFile
+    internal abstract val publicationFile: Property<File>
+
     @TaskAction
     fun bufBuild() {
-        execBuf("build", "--output", bufBuildPublicationFile)
+        execBuf("build", "--output", publicationFile.get())
     }
 }

--- a/src/main/kotlin/build/buf/gradle/ConfigSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ConfigSupport.kt
@@ -15,7 +15,6 @@
 package build.buf.gradle
 
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.tasks.Copy
 import org.gradle.kotlin.dsl.register
 import java.io.File
@@ -46,8 +45,6 @@ internal fun Project.bufConfigFile() =
             }
         }
     }
-
-internal fun Task.bufConfigFile() = project.bufConfigFile()
 
 private fun Project.resolveConfig(): File? {
     val ext = getExtension()

--- a/src/main/kotlin/build/buf/gradle/ConfigSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ConfigSupport.kt
@@ -24,7 +24,7 @@ const val COPY_BUF_CONFIG_TASK_NAME = "copyBufConfig"
 internal fun Project.configureCopyBufConfig() {
     tasks.register<Copy>(COPY_BUF_CONFIG_TASK_NAME) {
         from(listOfNotNull(bufConfigFile()))
-        into(bufbuildDir)
+        into(project.bufbuildDir)
         rename { "buf.yaml" }
     }
 }

--- a/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
@@ -40,7 +40,9 @@ private fun AbstractBufExecTask.execBufInSpecificDirectory(
 
     when {
         hasProtobufGradlePlugin.get() ->
-            project.projectDefinedProtoDirs().forEach { execBuf(runWithArgs(it), customErrorMessage) }
+            candidateProtoDirs
+                .filter { anyProtos(it) }
+                .forEach { execBuf(runWithArgs(it), customErrorMessage) }
         hasWorkspace.get() ->
             execBuf(bufCommand, customErrorMessage)
         else ->

--- a/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
@@ -14,17 +14,16 @@
 
 package build.buf.gradle
 
-import org.gradle.api.Task
 import java.io.File
 
-internal fun Task.execBufInSpecificDirectory(
+internal fun AbstractBufExecTask.execBufInSpecificDirectory(
     vararg bufCommand: String,
     customErrorMessage: ((String) -> String)? = null,
 ) {
     execBufInSpecificDirectory(bufCommand.asList(), emptyList(), customErrorMessage)
 }
 
-internal fun Task.execBufInSpecificDirectory(
+internal fun AbstractBufExecTask.execBufInSpecificDirectory(
     bufCommand: String,
     extraArgs: Iterable<String>,
     customErrorMessage: (String) -> String,
@@ -32,7 +31,7 @@ internal fun Task.execBufInSpecificDirectory(
     execBufInSpecificDirectory(listOf(bufCommand), extraArgs, customErrorMessage)
 }
 
-private fun Task.execBufInSpecificDirectory(
+private fun AbstractBufExecTask.execBufInSpecificDirectory(
     bufCommand: Iterable<String>,
     extraArgs: Iterable<String>,
     customErrorMessage: ((String) -> String)? = null,

--- a/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
@@ -39,7 +39,7 @@ private fun AbstractBufExecTask.execBufInSpecificDirectory(
     fun runWithArgs(file: File? = null) = bufCommand + listOfNotNull(file?.let { makeMangledRelativizedPathStr(it) }) + extraArgs
 
     when {
-        project.hasProtobufGradlePlugin() ->
+        hasProtobufGradlePlugin.get() ->
             project.projectDefinedProtoDirs().forEach { execBuf(runWithArgs(it), customErrorMessage) }
         hasWorkspace.get() ->
             execBuf(bufCommand, customErrorMessage)

--- a/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
@@ -36,7 +36,7 @@ private fun AbstractBufExecTask.execBufInSpecificDirectory(
     extraArgs: Iterable<String>,
     customErrorMessage: ((String) -> String)? = null,
 ) {
-    fun runWithArgs(file: File? = null) = bufCommand + listOfNotNull(file?.let { project.makeMangledRelativizedPathStr(it) }) + extraArgs
+    fun runWithArgs(file: File? = null) = bufCommand + listOfNotNull(file?.let { makeMangledRelativizedPathStr(it) }) + extraArgs
 
     when {
         project.hasProtobufGradlePlugin() ->

--- a/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/DirectorySpecificBufExecutionSupport.kt
@@ -41,7 +41,7 @@ private fun AbstractBufExecTask.execBufInSpecificDirectory(
     when {
         project.hasProtobufGradlePlugin() ->
             project.projectDefinedProtoDirs().forEach { execBuf(runWithArgs(it), customErrorMessage) }
-        project.hasWorkspace() ->
+        hasWorkspace.get() ->
             execBuf(bufCommand, customErrorMessage)
         else ->
             execBuf(runWithArgs(), customErrorMessage)

--- a/src/main/kotlin/build/buf/gradle/ExtensionSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ExtensionSupport.kt
@@ -15,7 +15,6 @@
 package build.buf.gradle
 
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.getByName
 
@@ -26,8 +25,6 @@ internal fun Project.createExtension() {
 }
 
 internal fun Project.getExtension() = extensions.getByName<BufExtension>(BUF_EXTENSION_NAME)
-
-internal fun Task.getExtension() = project.getExtension()
 
 internal fun Project.runBreakageCheck() =
     with(getExtension()) {

--- a/src/main/kotlin/build/buf/gradle/FormatApplyTask.kt
+++ b/src/main/kotlin/build/buf/gradle/FormatApplyTask.kt
@@ -14,10 +14,9 @@
 
 package build.buf.gradle
 
-import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
-abstract class FormatApplyTask : DefaultTask() {
+abstract class FormatApplyTask : AbstractBufExecTask() {
     @TaskAction
     fun bufFormatApply() {
         execBufInSpecificDirectory("format", "-w")

--- a/src/main/kotlin/build/buf/gradle/FormatApplyTask.kt
+++ b/src/main/kotlin/build/buf/gradle/FormatApplyTask.kt
@@ -14,9 +14,20 @@
 
 package build.buf.gradle
 
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.TaskAction
 
 abstract class FormatApplyTask : AbstractBufExecTask() {
+    /** The input files to be formatted. */
+    @get:InputFiles
+    internal abstract val inputFiles: ConfigurableFileCollection
+
+    /** The output files that have been formatted. */
+    @get:OutputFiles
+    internal abstract val outputFiles: ConfigurableFileCollection
+
     @TaskAction
     fun bufFormatApply() {
         execBufInSpecificDirectory("format", "-w")

--- a/src/main/kotlin/build/buf/gradle/FormatCheckTask.kt
+++ b/src/main/kotlin/build/buf/gradle/FormatCheckTask.kt
@@ -14,10 +14,9 @@
 
 package build.buf.gradle
 
-import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
-abstract class FormatCheckTask : DefaultTask() {
+abstract class FormatCheckTask : AbstractBufExecTask() {
     @TaskAction
     fun bufFormatCheck() {
         execBufInSpecificDirectory("format", "-d", "--exit-code") {

--- a/src/main/kotlin/build/buf/gradle/FormatCheckTask.kt
+++ b/src/main/kotlin/build/buf/gradle/FormatCheckTask.kt
@@ -14,9 +14,15 @@
 
 package build.buf.gradle
 
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
 
 abstract class FormatCheckTask : AbstractBufExecTask() {
+    /** The input files to be checked. */
+    @get:InputFiles
+    internal abstract val inputFiles: ConfigurableFileCollection
+
     @TaskAction
     fun bufFormatCheck() {
         execBufInSpecificDirectory("format", "-d", "--exit-code") {

--- a/src/main/kotlin/build/buf/gradle/FormatConfiguration.kt
+++ b/src/main/kotlin/build/buf/gradle/FormatConfiguration.kt
@@ -27,7 +27,7 @@ internal fun Project.configureFormat() {
 }
 
 private fun Project.configureBufFormatCheck() {
-    registerBufTask<FormatCheckTask>(BUF_FORMAT_CHECK_TASK_NAME) {
+    registerBufExecTask<FormatCheckTask>(BUF_FORMAT_CHECK_TASK_NAME) {
         group = VERIFICATION_GROUP
         description = "Checks that a Protobuf schema is formatted according to Buf's formatting rules."
         enabled = getExtension().enforceFormat
@@ -37,7 +37,7 @@ private fun Project.configureBufFormatCheck() {
 }
 
 private fun Project.configureBufFormatApply() {
-    registerBufTask<FormatApplyTask>(BUF_FORMAT_APPLY_TASK_NAME) {
+    registerBufExecTask<FormatApplyTask>(BUF_FORMAT_APPLY_TASK_NAME) {
         group = VERIFICATION_GROUP
         description = "Formats a Protobuf schema according to Buf's formatting rules."
     }

--- a/src/main/kotlin/build/buf/gradle/FormatConfiguration.kt
+++ b/src/main/kotlin/build/buf/gradle/FormatConfiguration.kt
@@ -31,6 +31,8 @@ private fun Project.configureBufFormatCheck() {
         group = VERIFICATION_GROUP
         description = "Checks that a Protobuf schema is formatted according to Buf's formatting rules."
         enabled = getExtension().enforceFormat
+
+        inputFiles.setFrom(obtainDefaultProtoFileSet())
     }
 
     tasks.named(CHECK_TASK_NAME).dependsOn(BUF_FORMAT_CHECK_TASK_NAME)
@@ -40,5 +42,8 @@ private fun Project.configureBufFormatApply() {
     registerBufExecTask<FormatApplyTask>(BUF_FORMAT_APPLY_TASK_NAME) {
         group = VERIFICATION_GROUP
         description = "Formats a Protobuf schema according to Buf's formatting rules."
+
+        inputFiles.setFrom(obtainDefaultProtoFileSet())
+        outputFiles.setFrom(obtainDefaultProtoFileSet())
     }
 }

--- a/src/main/kotlin/build/buf/gradle/GenerateConfiguration.kt
+++ b/src/main/kotlin/build/buf/gradle/GenerateConfiguration.kt
@@ -22,7 +22,7 @@ const val BUF_GENERATE_TASK_NAME = "bufGenerate"
 const val GENERATED_DIR = "generated"
 
 internal fun Project.configureGenerate() {
-    registerBufTask<GenerateTask>(BUF_GENERATE_TASK_NAME) {
+    registerBufExecTask<GenerateTask>(BUF_GENERATE_TASK_NAME) {
         group = BUILD_GROUP
         description = "Generates code from a Protobuf schema."
 

--- a/src/main/kotlin/build/buf/gradle/GenerateConfiguration.kt
+++ b/src/main/kotlin/build/buf/gradle/GenerateConfiguration.kt
@@ -16,6 +16,7 @@ package build.buf.gradle
 
 import org.gradle.api.Project
 import org.gradle.language.base.plugins.LifecycleBasePlugin.BUILD_GROUP
+import java.io.File
 
 const val BUF_GENERATE_TASK_NAME = "bufGenerate"
 
@@ -26,6 +27,31 @@ internal fun Project.configureGenerate() {
         group = BUILD_GROUP
         description = "Generates code from a Protobuf schema."
 
-        createsOutput()
+        val generateOptions = project.getExtension().generateOptions
+        includeImports.set(generateOptions?.includeImports ?: false)
+        templateFile.set(generateOptions?.let { resolveTemplateFile(it) })
+        inputFiles.setFrom(obtainDefaultProtoFileSet())
+        outputDirectory.set(File(project.bufbuildDir, GENERATED_DIR))
     }
 }
+
+private fun Project.resolveTemplateFile(generateOptions: GenerateOptions): File {
+    val defaultTemplateFile = project.file("buf.gen.yaml").validOrNull()
+    return if (generateOptions.templateFileLocation != null) {
+        val specifiedTemplateFile = generateOptions.templateFileLocation.validOrNull()
+        check(specifiedTemplateFile != null) {
+            "Specified templateFileLocation does not exist."
+        }
+        check(defaultTemplateFile == null || specifiedTemplateFile == defaultTemplateFile) {
+            "Buf gen template file specified in the project directory as well as with templateFileLocation; pick one."
+        }
+        specifiedTemplateFile
+    } else {
+        check(defaultTemplateFile != null) {
+            "No buf.gen.yaml file found in the project directory."
+        }
+        defaultTemplateFile
+    }
+}
+
+private fun File?.validOrNull() = this?.takeIf { it.isFile && it.exists() }

--- a/src/main/kotlin/build/buf/gradle/GenerateTask.kt
+++ b/src/main/kotlin/build/buf/gradle/GenerateTask.kt
@@ -14,11 +14,10 @@
 
 package build.buf.gradle
 
-import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
-abstract class GenerateTask : DefaultTask() {
+abstract class GenerateTask : AbstractBufExecTask() {
     @TaskAction
     fun bufGenerate() {
         val args = listOf("generate", "--output", File(bufbuildDir, GENERATED_DIR))

--- a/src/main/kotlin/build/buf/gradle/GenerateTask.kt
+++ b/src/main/kotlin/build/buf/gradle/GenerateTask.kt
@@ -14,53 +14,53 @@
 
 package build.buf.gradle
 
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
 abstract class GenerateTask : AbstractBufExecTask() {
+    /** Whether to include imports. */
+    @get:Input
+    internal abstract val includeImports: Property<Boolean>
+
+    /** Template file. */
+    @get:InputFile
+    @get:Optional
+    internal abstract val templateFile: Property<File>
+
+    /** The input proto files. */
+    @get:InputFiles
+    internal abstract val inputFiles: ConfigurableFileCollection
+
+    /** The directory to output generated files. */
+    @get:OutputDirectory
+    internal abstract val outputDirectory: Property<File>
+
     @TaskAction
     fun bufGenerate() {
-        val args = listOf("generate", "--output", File(bufbuildDir, GENERATED_DIR))
+        val args = listOf("generate", "--output", outputDirectory.get())
         execBuf(args + additionalArgs())
     }
 
     private fun additionalArgs(): List<String> {
-        val generateOptions = getExtension().generateOptions
         val importOptions =
-            if (generateOptions?.includeImports == true) {
+            if (includeImports.get()) {
                 listOf("--include-imports")
             } else {
                 emptyList()
             }
 
         val templateFileOption =
-            resolveTemplateFile()?.let {
+            templateFile.orNull?.let {
                 listOf("--template", it.absolutePath)
             } ?: emptyList()
 
         return importOptions + templateFileOption
     }
-
-    private fun resolveTemplateFile(): File? {
-        return getExtension().generateOptions?.let { generateOptions ->
-            val defaultTemplateFile = project.file("buf.gen.yaml").validOrNull()
-            if (generateOptions.templateFileLocation != null) {
-                val specifiedTemplateFile = generateOptions.templateFileLocation.validOrNull()
-                check(specifiedTemplateFile != null) {
-                    "Specified templateFileLocation does not exist."
-                }
-                check(defaultTemplateFile == null || specifiedTemplateFile == defaultTemplateFile) {
-                    "Buf gen template file specified in the project directory as well as with templateFileLocation; pick one."
-                }
-                specifiedTemplateFile
-            } else {
-                check(defaultTemplateFile != null) {
-                    "No buf.gen.yaml file found in the project directory."
-                }
-                defaultTemplateFile
-            }
-        }
-    }
-
-    private fun File?.validOrNull() = this?.takeIf { it.isFile && it.exists() }
 }

--- a/src/main/kotlin/build/buf/gradle/GradleSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/GradleSupport.kt
@@ -15,7 +15,6 @@
 package build.buf.gradle
 
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.dependencies
 
@@ -32,5 +31,3 @@ internal fun Project.createConfigurationWithDependency(
 }
 
 internal fun Project.singleFileFromConfiguration(configuration: String) = configurations.getByName(configuration).singleFile
-
-internal fun Task.singleFileFromConfiguration(configuration: String) = project.singleFileFromConfiguration(configuration)

--- a/src/main/kotlin/build/buf/gradle/LintConfiguration.kt
+++ b/src/main/kotlin/build/buf/gradle/LintConfiguration.kt
@@ -21,7 +21,7 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin.VERIFICATION_GROUP
 const val BUF_LINT_TASK_NAME = "bufLint"
 
 internal fun Project.configureLint() {
-    registerBufTask<LintTask>(BUF_LINT_TASK_NAME) {
+    registerBufExecTask<LintTask>(BUF_LINT_TASK_NAME) {
         group = VERIFICATION_GROUP
         description = "Checks that a Protobuf schema conforms to the Buf lint configuration."
     }

--- a/src/main/kotlin/build/buf/gradle/LintConfiguration.kt
+++ b/src/main/kotlin/build/buf/gradle/LintConfiguration.kt
@@ -24,6 +24,9 @@ internal fun Project.configureLint() {
     registerBufExecTask<LintTask>(BUF_LINT_TASK_NAME) {
         group = VERIFICATION_GROUP
         description = "Checks that a Protobuf schema conforms to the Buf lint configuration."
+
+        bufConfigFile.set(project.bufConfigFile())
+        inputFiles.setFrom(obtainDefaultProtoFileSet())
     }
 
     tasks.named(CHECK_TASK_NAME).dependsOn(BUF_LINT_TASK_NAME)

--- a/src/main/kotlin/build/buf/gradle/LintTask.kt
+++ b/src/main/kotlin/build/buf/gradle/LintTask.kt
@@ -14,17 +14,31 @@
 
 package build.buf.gradle
 
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.nio.file.Files.lines
 import kotlin.streams.asSequence
 
 abstract class LintTask : AbstractBufExecTask() {
+    /** The input proto files. */
+    @get:InputFiles
+    internal abstract val inputFiles: ConfigurableFileCollection
+
+    /** The input buf configuration file. */
+    @get:InputFile
+    @get:Optional
+    internal abstract val bufConfigFile: Property<File>
+
     @TaskAction
     fun bufLint() {
         execBufInSpecificDirectory(
             "lint",
-            bufConfigFile()?.let { listOf("--config", it.readAndStripComments()) }.orEmpty(),
+            bufConfigFile.orNull?.let { listOf("--config", it.readAndStripComments()) }.orEmpty(),
         ) {
             """
                  |Some Protobuf files had lint violations:

--- a/src/main/kotlin/build/buf/gradle/LintTask.kt
+++ b/src/main/kotlin/build/buf/gradle/LintTask.kt
@@ -14,13 +14,12 @@
 
 package build.buf.gradle
 
-import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.nio.file.Files.lines
 import kotlin.streams.asSequence
 
-abstract class LintTask : DefaultTask() {
+abstract class LintTask : AbstractBufExecTask() {
     @TaskAction
     fun bufLint() {
         execBufInSpecificDirectory(

--- a/src/main/kotlin/build/buf/gradle/OutputSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/OutputSupport.kt
@@ -15,14 +15,10 @@
 package build.buf.gradle
 
 import org.gradle.api.Project
-import org.gradle.api.Task
 
 const val BUF_BUILD_DIR = "bufbuild"
 
 internal val Project.bufbuildDir
     get() = layout.buildDirectory.dir(BUF_BUILD_DIR).get().asFile
-
-internal val Task.bufbuildDir
-    get() = project.bufbuildDir
 
 internal fun ArtifactDetails.groupAndArtifact() = "$groupId:$artifactId"

--- a/src/main/kotlin/build/buf/gradle/OutputSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/OutputSupport.kt
@@ -25,8 +25,4 @@ internal val Project.bufbuildDir
 internal val Task.bufbuildDir
     get() = project.bufbuildDir
 
-internal fun Task.createsOutput() {
-    doFirst { project.bufbuildDir.mkdirs() }
-}
-
 internal fun ArtifactDetails.groupAndArtifact() = "$groupId:$artifactId"

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -181,7 +181,7 @@ private fun anyProtos(directory: File) = directory.walkTopDown().any { it.extens
 
 private fun mangle(name: Path) = name.toString().replace("-", "--").replace(File.separator, "-")
 
-internal inline fun <reified T : Task> Project.registerBufTask(
+internal inline fun <reified T : AbstractBufExecTask> Project.registerBufTask(
     name: String,
     noinline configuration: T.() -> Unit,
 ): TaskProvider<T> {

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -239,8 +239,10 @@ internal inline fun <reified T : AbstractBufExecTask> Project.registerBufExecTas
         if (project.hasProtobufGradlePlugin()) {
             hasProtobufGradlePlugin.set(true)
             candidateProtoDirs.setFrom(projectDefinedProtoDirs())
+            workingDir.set(bufbuildDir)
         } else {
             hasProtobufGradlePlugin.set(false)
+            workingDir.set(project.projectDir)
         }
         hasWorkspace.set(project.hasWorkspace())
         configuration()

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -239,7 +239,9 @@ internal inline fun <reified T : AbstractBufExecTask> Project.registerBufExecTas
         if (project.hasProtobufGradlePlugin()) {
             hasProtobufGradlePlugin.set(true)
             candidateProtoDirs.setFrom(projectDefinedProtoDirs())
-            workingDir.set(bufbuildDir)
+            workingDir.set(project.bufbuildDir)
+            // whenever this task is part of the build, we must run it before any buf execution
+            mustRunAfter(COPY_BUF_CONFIG_TASK_NAME)
         } else {
             hasProtobufGradlePlugin.set(false)
             workingDir.set(project.projectDir)

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -173,7 +173,7 @@ private fun ExtensionAware.projectProtoSourceSetDirs() =
     extensions.getByName<SourceDirectorySet>("proto").srcDirs
         .toSet()
 
-internal fun AbstractBufTask.makeMangledRelativizedPathStr(file: File) = mangle(project.projectDir.toPath().relativize(file.toPath()))
+internal fun AbstractBufTask.makeMangledRelativizedPathStr(file: File) = mangle(projectDir.get().toPath().relativize(file.toPath()))
 
 // Indicates if the specified directory contains any proto files.
 private fun anyProtos(directory: File) = directory.walkTopDown().any { it.extension == "proto" }
@@ -183,7 +183,11 @@ private fun mangle(name: Path) = name.toString().replace("-", "--").replace(File
 internal inline fun <reified T : AbstractBufTask> Project.registerBufTask(
     name: String,
     noinline configuration: T.() -> Unit,
-): TaskProvider<T> = tasks.register(name, configuration)
+): TaskProvider<T> =
+    tasks.register<T>(name) {
+        projectDir.set(project.projectDir)
+        configuration()
+    }
 
 internal inline fun <reified T : AbstractBufExecTask> Project.registerBufExecTask(
     name: String,

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -238,6 +238,7 @@ internal inline fun <reified T : AbstractBufExecTask> Project.registerBufExecTas
 ): TaskProvider<T> =
     registerBufTask<T>(name) {
         bufExecutable.setFrom(configurations.getByName(BUF_BINARY_CONFIGURATION_NAME))
+        hasWorkspace.set(project.hasWorkspace())
         configuration()
     }.also { taskProvider ->
         withProtobufGradlePlugin {

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -15,7 +15,6 @@
 package build.buf.gradle
 
 import io.github.g00fy2.versioncompare.Version
-import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.SourceDirectorySet
@@ -57,7 +56,7 @@ internal fun Project.configureCreateSymLinksToModules() {
     }
 }
 
-abstract class CreateSymLinksToModulesTask : DefaultTask() {
+abstract class CreateSymLinksToModulesTask : AbstractBufTask() {
     @TaskAction
     fun createSymLinksToModules() {
         allProtoDirs()
@@ -81,7 +80,7 @@ internal fun Project.configureWriteWorkspaceYaml() {
     }
 }
 
-abstract class WriteWorkspaceYamlTask : DefaultTask() {
+abstract class WriteWorkspaceYamlTask : AbstractBufTask() {
     private val bufYamlGenerator = BufYamlGenerator()
 
     @TaskAction

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -142,7 +142,7 @@ private fun Task.allProtoDirs() =
 internal fun Project.projectDefinedProtoDirs() = allProtoSourceSetDirs() - file(Paths.get(BUILD_EXTRACTED_PROTOS_MAIN))
 
 // Returns deduplicated list of all proto source set directories.
-private fun Project.allProtoSourceSetDirs() = projectProtoSourceSetDirs() + androidProtoSourceSetDirs()
+private fun Project.allProtoSourceSetDirs() = projectProtoSourceSetDirs().filter { anyProtos(it) } + androidProtoSourceSetDirs()
 
 // Returns android proto source set directories that protobuf-gradle-plugin will codegen.
 private fun Project.androidProtoSourceSetDirs() =
@@ -160,7 +160,6 @@ private fun Project.androidProtoSourceSetDirs() =
 // Returns all proto source set directories that the protobuf-gradle-plugin will codegen.
 private fun Project.projectProtoSourceSetDirs() =
     the<SourceSetContainer>().flatMap { it.projectProtoSourceSetDirs() }
-        .filter { anyProtos(it) }
         .toSet()
 
 // Returns all directories within the "proto" source set of the receiver that actually contain proto files. This includes

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -157,7 +157,6 @@ private fun Task.workspaceCommonConfig() {
             .tasks
             .matching { it::class.java.name == "com.google.protobuf.gradle.ProtobufExtract_Decorated" },
     )
-    createsOutput()
 }
 
 private fun WriteWorkspaceYamlTask.workspaceSymLinkEntries() =

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -236,7 +236,10 @@ internal inline fun <reified T : AbstractBufExecTask> Project.registerBufExecTas
     name: String,
     noinline configuration: T.() -> Unit,
 ): TaskProvider<T> =
-    registerBufTask(name, configuration).also { taskProvider ->
+    registerBufTask<T>(name) {
+        bufExecutable.setFrom(configurations.getByName(BUF_BINARY_CONFIGURATION_NAME))
+        configuration()
+    }.also { taskProvider ->
         withProtobufGradlePlugin {
             afterEvaluate {
                 taskProvider.dependsOn(CREATE_SYM_LINKS_TO_MODULES_TASK_NAME)

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -181,7 +181,7 @@ private fun anyProtos(directory: File) = directory.walkTopDown().any { it.extens
 
 private fun mangle(name: Path) = name.toString().replace("-", "--").replace(File.separator, "-")
 
-internal inline fun <reified T : AbstractBufExecTask> Project.registerBufTask(
+internal inline fun <reified T : AbstractBufExecTask> Project.registerBufExecTask(
     name: String,
     noinline configuration: T.() -> Unit,
 ): TaskProvider<T> {

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -116,7 +116,7 @@ private fun Task.workspaceCommonConfig() {
     createsOutput()
 }
 
-private fun Task.workspaceSymLinkEntries() =
+private fun WriteWorkspaceYamlTask.workspaceSymLinkEntries() =
     allProtoDirs()
         .filter { anyProtos(it) }
         .map { project.makeMangledRelativizedPathStr(it) }

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -62,7 +62,7 @@ abstract class CreateSymLinksToModulesTask : AbstractBufTask() {
         allProtoDirs()
             .filter { anyProtos(it) }
             .forEach {
-                val symLinkFile = File(bufbuildDir, project.makeMangledRelativizedPathStr(it))
+                val symLinkFile = File(bufbuildDir, makeMangledRelativizedPathStr(it))
                 if (!symLinkFile.exists()) {
                     logger.info("Creating symlink for $it at $symLinkFile")
                     Files.createSymbolicLink(
@@ -99,7 +99,7 @@ abstract class WriteWorkspaceYamlTask : AbstractBufTask() {
             val protoDirs =
                 allProtoDirs()
                     .filter { anyProtos(it) }
-                    .map { project.makeMangledRelativizedPathStr(it) }
+                    .map { makeMangledRelativizedPathStr(it) }
             val bufYaml = bufYamlGenerator.generate(project.bufConfigFile(), protoDirs)
             logger.info("Writing generated buf.yaml:{}\n", bufYaml)
             File(bufbuildDir, "buf.yaml").writeText(bufYaml)
@@ -119,7 +119,7 @@ private fun Task.workspaceCommonConfig() {
 private fun WriteWorkspaceYamlTask.workspaceSymLinkEntries() =
     allProtoDirs()
         .filter { anyProtos(it) }
-        .map { project.makeMangledRelativizedPathStr(it) }
+        .map { makeMangledRelativizedPathStr(it) }
         .joinToString("\n") { "|  - $it" }
 
 // Returns all directories that have may have proto files relevant to processing the project's proto files. This
@@ -173,7 +173,7 @@ private fun ExtensionAware.projectProtoSourceSetDirs() =
     extensions.getByName<SourceDirectorySet>("proto").srcDirs
         .toSet()
 
-internal fun Project.makeMangledRelativizedPathStr(file: File) = mangle(projectDir.toPath().relativize(file.toPath()))
+internal fun AbstractBufTask.makeMangledRelativizedPathStr(file: File) = mangle(project.projectDir.toPath().relativize(file.toPath()))
 
 // Indicates if the specified directory contains any proto files.
 private fun anyProtos(directory: File) = directory.walkTopDown().any { it.extension == "proto" }

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -139,13 +139,12 @@ private fun Task.allProtoDirs() =
 //
 // Protobuf-gradle-plugin change that introduced this behavior: https://github.com/google/protobuf-gradle-plugin/pull/637/
 // Line: https://github.com/google/protobuf-gradle-plugin/blob/9d2a328a0d577bf4439d3b482a953715b3a03027/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy#L425
-internal fun Project.projectDefinedProtoDirs() = allProtoSourceSetDirs() - file(Paths.get(BUILD_EXTRACTED_PROTOS_MAIN))
+internal fun Project.projectDefinedProtoDirs() =
+    (allProtoSourceSetDirs() - file(Paths.get(BUILD_EXTRACTED_PROTOS_MAIN)))
+        .filter { anyProtos(it) }
 
 // Returns deduplicated list of all proto source set directories.
-private fun Project.allProtoSourceSetDirs() =
-    projectProtoSourceSetDirs().filter {
-        anyProtos(it)
-    } + androidProtoSourceSetDirs().filter { anyProtos(it) }
+private fun Project.allProtoSourceSetDirs() = projectProtoSourceSetDirs() + androidProtoSourceSetDirs()
 
 // Returns android proto source set directories that protobuf-gradle-plugin will codegen.
 private fun Project.androidProtoSourceSetDirs() =

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -238,6 +238,7 @@ internal inline fun <reified T : AbstractBufExecTask> Project.registerBufExecTas
 ): TaskProvider<T> =
     registerBufTask<T>(name) {
         bufExecutable.setFrom(configurations.getByName(BUF_BINARY_CONFIGURATION_NAME))
+        hasProtobufGradlePlugin.set(project.hasProtobufGradlePlugin())
         hasWorkspace.set(project.hasWorkspace())
         configuration()
     }.also { taskProvider ->

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -154,18 +154,19 @@ private fun Project.androidProtoSourceSetDirs() =
         }
         .orEmpty()
         .flatMap { it.projectProtoSourceSetDirs() }
+        .filter { anyProtos(it) }
         .toSet()
 
 // Returns all proto source set directories that the protobuf-gradle-plugin will codegen.
 private fun Project.projectProtoSourceSetDirs() =
     the<SourceSetContainer>().flatMap { it.projectProtoSourceSetDirs() }
+        .filter { anyProtos(it) }
         .toSet()
 
 // Returns all directories within the "proto" source set of the receiver that actually contain proto files. This includes
 // directories explicitly added to the source set, as well as directories containing files from "protobuf" dependencies.
 private fun ExtensionAware.projectProtoSourceSetDirs() =
     extensions.getByName<SourceDirectorySet>("proto").srcDirs
-        .filter { anyProtos(it) }
         .toSet()
 
 internal fun Project.makeMangledRelativizedPathStr(file: File) = mangle(projectDir.toPath().relativize(file.toPath()))

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -142,7 +142,10 @@ private fun Task.allProtoDirs() =
 internal fun Project.projectDefinedProtoDirs() = allProtoSourceSetDirs() - file(Paths.get(BUILD_EXTRACTED_PROTOS_MAIN))
 
 // Returns deduplicated list of all proto source set directories.
-private fun Project.allProtoSourceSetDirs() = projectProtoSourceSetDirs().filter { anyProtos(it) } + androidProtoSourceSetDirs()
+private fun Project.allProtoSourceSetDirs() =
+    projectProtoSourceSetDirs().filter {
+        anyProtos(it)
+    } + androidProtoSourceSetDirs().filter { anyProtos(it) }
 
 // Returns android proto source set directories that protobuf-gradle-plugin will codegen.
 private fun Project.androidProtoSourceSetDirs() =
@@ -154,7 +157,6 @@ private fun Project.androidProtoSourceSetDirs() =
         }
         .orEmpty()
         .flatMap { it.projectProtoSourceSetDirs() }
-        .filter { anyProtos(it) }
         .toSet()
 
 // Returns all proto source set directories that the protobuf-gradle-plugin will codegen.

--- a/src/test/kotlin/build/buf/gradle/AbstractBufIntegrationTest.kt
+++ b/src/test/kotlin/build/buf/gradle/AbstractBufIntegrationTest.kt
@@ -71,6 +71,7 @@ abstract class AbstractBufIntegrationTest : IntegrationTest {
                 "-PprotobufVersion=3.23.4",
                 "-PkotlinVersion=1.7.20",
                 "-PandroidGradleVersion=7.3.0",
+                "--configuration-cache",
             )
             .withDebug(false) // Enable for interactive debugging
             .let { WrappedRunner(it) }

--- a/src/test/resources/GenerateTest/buf_generate_fails_with_a_nonexistent_specified_template_file/build.gradle
+++ b/src/test/resources/GenerateTest/buf_generate_fails_with_a_nonexistent_specified_template_file/build.gradle
@@ -2,6 +2,11 @@ plugins {
   id 'build.buf'
 }
 
+
+repositories {
+  mavenCentral()
+}
+
 buf {
   generate {
     templateFileLocation = project.file("subdir/buf.gen.yaml")

--- a/src/test/resources/GenerateTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/build.gradle
+++ b/src/test/resources/GenerateTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/build.gradle
@@ -2,6 +2,10 @@ plugins {
   id 'build.buf'
 }
 
+repositories {
+  mavenCentral()
+}
+
 buf {
   generate {
     templateFileLocation = project.file("subdir/buf.gen.yaml")

--- a/src/test/resources/GenerateTest/buf_generate_fails_with_no_default_template_file_and_no_override_specified/build.gradle
+++ b/src/test/resources/GenerateTest/buf_generate_fails_with_no_default_template_file_and_no_override_specified/build.gradle
@@ -2,6 +2,10 @@ plugins {
   id 'build.buf'
 }
 
+repositories {
+  mavenCentral()
+}
+
 buf {
   generate {
   }

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_with_a_nonexistent_specified_template_file/build.gradle
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_with_a_nonexistent_specified_template_file/build.gradle
@@ -2,6 +2,10 @@ plugins {
   id 'build.buf'
 }
 
+repositories {
+  mavenCentral()
+}
+
 buf {
   generate {
     templateFileLocation = project.file("subdir/buf.gen.yaml")

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/build.gradle
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/build.gradle
@@ -2,6 +2,10 @@ plugins {
   id 'build.buf'
 }
 
+repositories {
+  mavenCentral()
+}
+
 buf {
   generate {
     templateFileLocation = project.file("subdir/buf.gen.yaml")

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_with_no_default_template_file_and_no_override_specified/build.gradle
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_with_no_default_template_file_and_no_override_specified/build.gradle
@@ -2,6 +2,10 @@ plugins {
   id 'build.buf'
 }
 
+repositories {
+  mavenCentral()
+}
+
 buf {
   generate {
   }


### PR DESCRIPTION
Support configuration cache.

This is the current standard for plugins. It makes the builds faster by supporting heavy parallelism in builds, and slow whenever a non-compliant plugin is part of the build.

I tried carefully to set all inputs / outputs of tasks. It is however quite hard to handle all imaginable cases.

The commits should be small and reviewable. If anything is not clear from the commits, I'm ready to explain.
