### PR TITLE
Add v2 buf.yaml Generate and Breaking test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ This plugin supports straightforward usage of `buf lint`, `buf format`, and `buf
 
 ## Usage
 
-This plugin assumes that Buf is configured for the project root with a configured `buf.work.yaml`, and instructions for setting up a Buf workspace can be found in the [Buf docs][buf-docs].
+This plugin assumes that Buf is configured for the project root with a configured `buf.yaml`, and instructions for setting up a Buf workspace can be found in the [Buf docs][buf-docs].
 
-The plugin can also be used without specifying a `buf.work.yaml`, in which case the plugin will scan all top-level directories for Protobuf sources.
+The plugin can also be used without specifying a `buf.yaml`, in which case the plugin will scan all top-level directories for Protobuf sources.
 
 If the project includes the `protobuf-gradle-plugin`, this plugin will use an implicit Buf workspace that includes the following:
 - All specified Protobuf source directories
@@ -60,7 +60,7 @@ For a basic Buf project or one that uses the `protobuf-gradle-plugin`, you can c
 ``` yaml
 # buf.yaml
 
-version: v1
+version: v2
 lint:
   ignore:
     - path/to/dir/to/ignore
@@ -125,7 +125,7 @@ If your `buf.yaml` declares any dependencies using the `deps` key, you must run 
 An example, for Java code generation using the remote plugin:
 
 ``` yaml
-version: v1
+version: v2
 plugins:
   - plugin: buf.build/protocolbuffers/java:<version>
     out: java

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
 
     implementation(libs.jacksonDataformatYaml)
     implementation(libs.jacksonModuleKotlin)
+    implementation(libs.versioncompare)
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ buildConfig = "5.4.0"
 # runtime
 bufbuild = "1.35.0"
 jackson = "2.17.2"
+versioncompare = "1.5.0"
 
 # test
 junit = "5.10.3"
@@ -26,6 +27,7 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 bufbuild = { module = "build.buf:buf", version.ref = "bufbuild" }
 jacksonDataformatYaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
 jacksonModuleKotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
+versioncompare = { module = "io.github.g00fy2:versioncompare", version.ref = "versioncompare" }
 
 # test
 junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }

--- a/src/main/kotlin/build/buf/gradle/BreakingTask.kt
+++ b/src/main/kotlin/build/buf/gradle/BreakingTask.kt
@@ -14,6 +14,7 @@
 
 package build.buf.gradle
 
+import io.github.g00fy2.versioncompare.Version
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 

--- a/src/main/kotlin/build/buf/gradle/BreakingTask.kt
+++ b/src/main/kotlin/build/buf/gradle/BreakingTask.kt
@@ -14,7 +14,6 @@
 
 package build.buf.gradle
 
-import io.github.g00fy2.versioncompare.Version
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 

--- a/src/main/kotlin/build/buf/gradle/BreakingTask.kt
+++ b/src/main/kotlin/build/buf/gradle/BreakingTask.kt
@@ -14,18 +14,21 @@
 
 package build.buf.gradle
 
+import io.github.g00fy2.versioncompare.Version
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
 abstract class BreakingTask : DefaultTask() {
     @TaskAction
     fun bufBreaking() {
-        execBuf(
-            "breaking",
-            bufBuildPublicationFile,
-            "--against",
-            singleFileFromConfiguration(BUF_BREAKING_CONFIGURATION_NAME),
-        ) {
+        val args = mutableListOf<Any>()
+        args.add("breaking")
+        if (Version(project.getExtension().toolVersion) < Version("1.32.0")) {
+            args.add(bufBuildPublicationFile)
+        }
+        args.add("--against")
+        args.add(singleFileFromConfiguration(BUF_BREAKING_CONFIGURATION_NAME))
+        execBuf(*args.toTypedArray()) {
             """
                 |Some Protobuf files had breaking changes:
                 |$it

--- a/src/main/kotlin/build/buf/gradle/BreakingTask.kt
+++ b/src/main/kotlin/build/buf/gradle/BreakingTask.kt
@@ -14,7 +14,6 @@
 
 package build.buf.gradle
 
-import io.github.g00fy2.versioncompare.Version
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
@@ -23,7 +22,7 @@ abstract class BreakingTask : DefaultTask() {
     fun bufBreaking() {
         val args = mutableListOf<Any>()
         args.add("breaking")
-        if (Version(project.getExtension().toolVersion) < Version("1.32.0")) {
+        if (project.bufV1SyntaxOnly()) {
             args.add(bufBuildPublicationFile)
         }
         args.add("--against")

--- a/src/main/kotlin/build/buf/gradle/BufPlugin.kt
+++ b/src/main/kotlin/build/buf/gradle/BufPlugin.kt
@@ -14,6 +14,7 @@
 
 package build.buf.gradle
 
+import io.github.g00fy2.versioncompare.Version
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.BasePlugin

--- a/src/main/kotlin/build/buf/gradle/BufPlugin.kt
+++ b/src/main/kotlin/build/buf/gradle/BufPlugin.kt
@@ -14,7 +14,6 @@
 
 package build.buf.gradle
 
-import io.github.g00fy2.versioncompare.Version
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.BasePlugin

--- a/src/main/kotlin/build/buf/gradle/BufYamlGenerator.kt
+++ b/src/main/kotlin/build/buf/gradle/BufYamlGenerator.kt
@@ -29,16 +29,17 @@ internal class BufYamlGenerator {
         // Emit a module for each discovered workspace, copying ignores and concatenating their
         // paths with the module root.
         val modules =
-            protoDirs.map { dir ->
-                if (ignores.isEmpty()) {
-                    mapOf("path" to dir)
-                } else {
-                    mapOf(
-                        "path" to dir,
-                        "breaking" to mapOf("ignore" to ignores.map { "$dir/$it" }),
-                    )
+            protoDirs
+                .map { dir ->
+                    if (ignores.isEmpty()) {
+                        mapOf("path" to dir)
+                    } else {
+                        mapOf(
+                            "path" to dir,
+                            "breaking" to mapOf("ignore" to ignores.map { "$dir/$it" }),
+                        )
+                    }
                 }
-            }
         bufYaml["modules"] = modules
         return mapper.writeValueAsString(bufYaml)
     }

--- a/src/main/kotlin/build/buf/gradle/BufYamlGenerator.kt
+++ b/src/main/kotlin/build/buf/gradle/BufYamlGenerator.kt
@@ -29,17 +29,16 @@ internal class BufYamlGenerator {
         // Emit a module for each discovered workspace, copying ignores and concatenating their
         // paths with the module root.
         val modules =
-            protoDirs
-                .map { dir ->
-                    if (ignores.isEmpty()) {
-                        mapOf("path" to dir)
-                    } else {
-                        mapOf(
-                            "path" to dir,
-                            "breaking" to mapOf("ignore" to ignores.map { "$dir/$it" }),
-                        )
-                    }
+            protoDirs.map { dir ->
+                if (ignores.isEmpty()) {
+                    mapOf("path" to dir)
+                } else {
+                    mapOf(
+                        "path" to dir,
+                        "breaking" to mapOf("ignore" to ignores.map { "$dir/$it" }),
+                    )
                 }
+            }
         bufYaml["modules"] = modules
         return mapper.writeValueAsString(bufYaml)
     }

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -36,6 +36,7 @@ import kotlin.reflect.full.declaredMemberProperties
 
 const val CREATE_SYM_LINKS_TO_MODULES_TASK_NAME = "createSymLinksToModules"
 const val WRITE_WORKSPACE_YAML_TASK_NAME = "writeWorkspaceYaml"
+const val BUF_CLI_V2_INITIAL_VERSION = "1.32.0"
 
 private val BUILD_EXTRACTED_INCLUDE_PROTOS_MAIN =
     listOf("build", "extracted-include-protos", "main").joinToString(File.separator)
@@ -44,6 +45,8 @@ private val BUILD_EXTRACTED_PROTOS_MAIN =
     listOf("build", "extracted-protos", "main").joinToString(File.separator)
 
 internal fun Project.hasProtobufGradlePlugin() = pluginManager.hasPlugin("com.google.protobuf")
+
+internal fun Project.bufV1SyntaxOnly() = Version(getExtension().toolVersion) < Version(BUF_CLI_V2_INITIAL_VERSION)
 
 internal fun Project.withProtobufGradlePlugin(action: (AppliedPlugin) -> Unit) = pluginManager.withPlugin("com.google.protobuf", action)
 
@@ -80,7 +83,7 @@ abstract class WriteWorkspaceYamlTask : DefaultTask() {
 
     @TaskAction
     fun writeWorkspaceYaml() {
-        if (Version(project.getExtension().toolVersion) < Version("1.32.0")) {
+        if (project.bufV1SyntaxOnly()) {
             val bufWork =
                 """
                 |version: v1

--- a/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/ProtobufGradlePluginSupport.kt
@@ -36,7 +36,8 @@ import kotlin.reflect.full.declaredMemberProperties
 
 const val CREATE_SYM_LINKS_TO_MODULES_TASK_NAME = "createSymLinksToModules"
 const val WRITE_WORKSPACE_YAML_TASK_NAME = "writeWorkspaceYaml"
-const val BUF_CLI_V2_INITIAL_VERSION = "1.32.0"
+
+internal const val BUF_CLI_V2_INITIAL_VERSION = "1.32.0"
 
 private val BUILD_EXTRACTED_INCLUDE_PROTOS_MAIN =
     listOf("build", "extracted-include-protos", "main").joinToString(File.separator)

--- a/src/test/kotlin/build/buf/gradle/AbstractBreakingTest.kt
+++ b/src/test/kotlin/build/buf/gradle/AbstractBreakingTest.kt
@@ -62,7 +62,7 @@ abstract class AbstractBreakingTest : AbstractBufIntegrationTest() {
         assertThat(result.output).contains("Cannot configure $BUF_BREAKING_TASK_NAME against latest release and a previous version.")
     }
 
-    private fun checkBreaking() {
+    protected fun checkBreaking() {
         checkRunner().build()
 
         buildFile.replace("//", "")
@@ -80,7 +80,7 @@ abstract class AbstractBreakingTest : AbstractBufIntegrationTest() {
         assertThat(result.output).contains("Previously present message \"BasicMessage\" was deleted from file.")
     }
 
-    private fun breakSchema() {
+    protected fun breakSchema() {
         val protoFile = protoFile().toFile()
         protoFile.replace("BasicMessage", "BasicMessage2")
     }

--- a/src/test/kotlin/build/buf/gradle/AbstractBreakingTest.kt
+++ b/src/test/kotlin/build/buf/gradle/AbstractBreakingTest.kt
@@ -62,7 +62,7 @@ abstract class AbstractBreakingTest : AbstractBufIntegrationTest() {
         assertThat(result.output).contains("Cannot configure $BUF_BREAKING_TASK_NAME against latest release and a previous version.")
     }
 
-    protected fun checkBreaking() {
+    private fun checkBreaking() {
         checkRunner().build()
 
         buildFile.replace("//", "")
@@ -80,7 +80,7 @@ abstract class AbstractBreakingTest : AbstractBufIntegrationTest() {
         assertThat(result.output).contains("Previously present message \"BasicMessage\" was deleted from file.")
     }
 
-    protected fun breakSchema() {
+    private fun breakSchema() {
         val protoFile = protoFile().toFile()
         protoFile.replace("BasicMessage", "BasicMessage2")
     }

--- a/src/test/kotlin/build/buf/gradle/BreakingWithWorkspaceTest.kt
+++ b/src/test/kotlin/build/buf/gradle/BreakingWithWorkspaceTest.kt
@@ -14,6 +14,8 @@
 
 package build.buf.gradle
 
+import build.buf.gradle.ImageGenerationSupport.replaceBuildDetails
+import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource

--- a/src/test/kotlin/build/buf/gradle/BreakingWithWorkspaceTest.kt
+++ b/src/test/kotlin/build/buf/gradle/BreakingWithWorkspaceTest.kt
@@ -14,8 +14,52 @@
 
 package build.buf.gradle
 
+import build.buf.gradle.ImageGenerationSupport.replaceBuildDetails
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import java.nio.file.Paths
 
 class BreakingWithWorkspaceTest : AbstractBreakingTest() {
     override fun protoFile() = Paths.get(projectDir.path, "workspace", "buf", "test", "v1", "test.proto")
+
+    @Test
+    fun `breaking schema v2`() {
+        publishRunner().build()
+        checkBreaking()
+    }
+
+    @Test
+    fun `breaking schema fails with latest-release and previousVersion v2`() {
+        val result = checkRunner().buildAndFail()
+        assertThat(result.output).contains("Cannot configure $BUF_BREAKING_TASK_NAME against latest release and a previous version.")
+    }
+
+    @Test
+    fun `breaking schema with latest-release as version v2`() {
+        publishRunner().build()
+        checkBreaking()
+    }
+
+    @ParameterizedTest
+    @MethodSource("build.buf.gradle.ImageGenerationSupport#publicationFileExtensionTestCase")
+    fun `breaking schema with specified publication file extension v2`(
+        format: String,
+        compression: String?,
+    ) {
+        replaceBuildDetails(format, compression)
+        publishRunner().build()
+        checkBreaking()
+    }
+
+    @Test
+    fun `normally breaking schema with an ignore v2`() {
+        publishRunner().build()
+
+        breakSchema()
+
+        buildFile.replace("//", "")
+        checkRunner().build()
+    }
 }

--- a/src/test/kotlin/build/buf/gradle/BreakingWithWorkspaceTest.kt
+++ b/src/test/kotlin/build/buf/gradle/BreakingWithWorkspaceTest.kt
@@ -14,8 +14,6 @@
 
 package build.buf.gradle
 
-import build.buf.gradle.ImageGenerationSupport.replaceBuildDetails
-import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -26,20 +24,17 @@ class BreakingWithWorkspaceTest : AbstractBreakingTest() {
 
     @Test
     fun `breaking schema v2`() {
-        publishRunner().build()
-        checkBreaking()
+        super.`breaking schema`()
     }
 
     @Test
     fun `breaking schema fails with latest-release and previousVersion v2`() {
-        val result = checkRunner().buildAndFail()
-        assertThat(result.output).contains("Cannot configure $BUF_BREAKING_TASK_NAME against latest release and a previous version.")
+        super.`breaking schema fails with latest-release and previousVersion`()
     }
 
     @Test
     fun `breaking schema with latest-release as version v2`() {
-        publishRunner().build()
-        checkBreaking()
+        super.`breaking schema with latest-release as version`()
     }
 
     @ParameterizedTest
@@ -48,18 +43,11 @@ class BreakingWithWorkspaceTest : AbstractBreakingTest() {
         format: String,
         compression: String?,
     ) {
-        replaceBuildDetails(format, compression)
-        publishRunner().build()
-        checkBreaking()
+        super.`breaking schema with specified publication file extension`(format, compression)
     }
 
     @Test
     fun `normally breaking schema with an ignore v2`() {
-        publishRunner().build()
-
-        breakSchema()
-
-        buildFile.replace("//", "")
-        checkRunner().build()
+        super.`normally breaking schema with an ignore`()
     }
 }

--- a/src/test/kotlin/build/buf/gradle/BreakingWithWorkspaceTest.kt
+++ b/src/test/kotlin/build/buf/gradle/BreakingWithWorkspaceTest.kt
@@ -14,8 +14,6 @@
 
 package build.buf.gradle
 
-import build.buf.gradle.ImageGenerationSupport.replaceBuildDetails
-import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource

--- a/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_fails_with_latest_release_and_previousversion_v2/buf.yaml
+++ b/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_fails_with_latest_release_and_previousversion_v2/buf.yaml
@@ -1,0 +1,3 @@
+version: v2
+modules:
+  - path: workspace

--- a/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_fails_with_latest_release_and_previousversion_v2/build.gradle
+++ b/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_fails_with_latest_release_and_previousversion_v2/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+  id 'java'
+  id 'build.buf'
+  id 'maven-publish'
+}
+
+repositories {
+  mavenCentral()
+  maven { url 'build/repos/test' }
+}
+
+buf {
+  publishSchema = true
+  checkSchemaAgainstLatestRelease = true
+  previousVersion = '2319'
+
+  imageArtifact {
+    groupId = 'foo'
+    artifactId = 'bar'
+    version = '2319'
+  }
+}

--- a/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_v2/buf.yaml
+++ b/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_v2/buf.yaml
@@ -1,0 +1,3 @@
+version: v2
+modules:
+  - path: workspace

--- a/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_v2/build.gradle
+++ b/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_v2/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+  id 'java'
+  id 'build.buf'
+  id 'maven-publish'
+}
+
+repositories {
+  mavenCentral()
+  maven { url 'build/repos/test' }
+}
+
+publishing {
+  repositories {
+    maven { url 'build/repos/test' }
+  }
+}
+
+buf {
+  publishSchema = true
+  //previousVersion = '2319'
+
+  imageArtifact {
+    groupId = 'foo'
+    artifactId = 'bar'
+    version = '2319'
+  }
+}

--- a/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_v2/workspace/buf/test/v1/test.proto
+++ b/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_v2/workspace/buf/test/v1/test.proto
@@ -1,0 +1,19 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.test.v1;
+
+message BasicMessage {}

--- a/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_with_latest_release_as_version_v2/buf.yaml
+++ b/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_with_latest_release_as_version_v2/buf.yaml
@@ -1,0 +1,3 @@
+version: v2
+modules:
+  - path: workspace

--- a/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_with_latest_release_as_version_v2/build.gradle
+++ b/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_with_latest_release_as_version_v2/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'java'
-  id 'com.google.protobuf' version "$protobufGradleVersion"
   id 'build.buf'
   id 'maven-publish'
 }
@@ -10,14 +9,6 @@ repositories {
   maven { url 'build/repos/test' }
 }
 
-protobuf {
-  protoc {
-    artifact = "com.google.protobuf:protoc:$protobufVersion"
-  }
-}
-
-compileJava.enabled = false
-
 publishing {
   repositories {
     maven { url 'build/repos/test' }
@@ -25,7 +16,6 @@ publishing {
 }
 
 buf {
-  toolVersion = "1.31.0"
   publishSchema = true
   //checkSchemaAgainstLatestRelease = true
 
@@ -34,8 +24,4 @@ buf {
     artifactId = 'bar'
     version = '2319'
   }
-}
-
-dependencies {
-  implementation "com.google.protobuf:protobuf-java:$protobufVersion"
 }

--- a/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_with_latest_release_as_version_v2/workspace/buf/test/v1/test.proto
+++ b/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_with_latest_release_as_version_v2/workspace/buf/test/v1/test.proto
@@ -1,0 +1,19 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.test.v1;
+
+message BasicMessage {}

--- a/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_with_specified_publication_file_extension_v2/buf.yaml
+++ b/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_with_specified_publication_file_extension_v2/buf.yaml
@@ -1,0 +1,3 @@
+version: v2
+modules:
+  - path: workspace

--- a/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_with_specified_publication_file_extension_v2/build.gradle
+++ b/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_with_specified_publication_file_extension_v2/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'java'
+    id 'build.buf'
+    id 'maven-publish'
+}
+
+repositories {
+    mavenCentral()
+    maven { url 'build/repos/test' }
+}
+
+publishing {
+    repositories {
+        maven { url 'build/repos/test' }
+    }
+}
+
+buf {
+    publishSchema = true
+    //previousVersion = '2319'
+
+    build {
+        imageFormat = REPLACEME
+        compressionFormat = REPLACEME
+    }
+
+    imageArtifact {
+        groupId = 'foo'
+        artifactId = 'bar'
+        version = '2319'
+    }
+}

--- a/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_with_specified_publication_file_extension_v2/workspace/buf/test/v1/test.proto
+++ b/src/test/resources/BreakingWithWorkspaceTest/breaking_schema_with_specified_publication_file_extension_v2/workspace/buf/test/v1/test.proto
@@ -1,0 +1,19 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.test.v1;
+
+message BasicMessage {}

--- a/src/test/resources/BreakingWithWorkspaceTest/normally_breaking_schema_with_an_ignore_v2/buf.yaml
+++ b/src/test/resources/BreakingWithWorkspaceTest/normally_breaking_schema_with_an_ignore_v2/buf.yaml
@@ -1,0 +1,6 @@
+version: v2
+modules:
+  - path: workspace
+    breaking:
+      ignore:
+        - workspace/buf

--- a/src/test/resources/BreakingWithWorkspaceTest/normally_breaking_schema_with_an_ignore_v2/build.gradle
+++ b/src/test/resources/BreakingWithWorkspaceTest/normally_breaking_schema_with_an_ignore_v2/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+  id 'java'
+  id 'build.buf'
+  id 'maven-publish'
+}
+
+repositories {
+  mavenCentral()
+  maven { url 'build/repos/test' }
+}
+
+publishing {
+  repositories {
+    maven { url 'build/repos/test' }
+  }
+}
+
+buf {
+  publishSchema = true
+  //previousVersion = '2319'
+
+  imageArtifact {
+    groupId = 'foo'
+    artifactId = 'bar'
+    version = '2319'
+  }
+}

--- a/src/test/resources/BreakingWithWorkspaceTest/normally_breaking_schema_with_an_ignore_v2/workspace/buf/test/v1/test.proto
+++ b/src/test/resources/BreakingWithWorkspaceTest/normally_breaking_schema_with_an_ignore_v2/workspace/buf/test/v1/test.proto
@@ -1,0 +1,19 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.test.v1;
+
+message BasicMessage {}

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_default_template_file_path_explicitly_specifying_v2/buf.gen.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_default_template_file_path_explicitly_specifying_v2/buf.gen.yaml
@@ -1,0 +1,4 @@
+version: v1
+plugins:
+  - plugin: buf.build/protocolbuffers/java:v23.4
+    out: java

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_default_template_file_path_explicitly_specifying_v2/buf.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_default_template_file_path_explicitly_specifying_v2/buf.yaml
@@ -1,0 +1,3 @@
+version: v2
+modules:
+  - path: workspace

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_default_template_file_path_explicitly_specifying_v2/build.gradle
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_default_template_file_path_explicitly_specifying_v2/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+  id 'java'
+  id 'build.buf'
+}
+
+repositories {
+  mavenCentral()
+}
+
+buf {
+  generate {
+    configFileLocation = rootProject.file("./buf.yaml")
+    templateFileLocation = project.file("./buf.gen.yaml")
+  }
+}
+
+compileJava.dependsOn 'bufGenerate'
+
+sourceSets.main.java {
+  srcDir 'build/bufbuild/generated/java'
+}
+
+dependencies {
+  implementation "com.google.protobuf:protobuf-java:$protobufVersion"
+}

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_default_template_file_path_explicitly_specifying_v2/src/main/java/buf/test/v1/Foo.java
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_default_template_file_path_explicitly_specifying_v2/src/main/java/buf/test/v1/Foo.java
@@ -1,0 +1,21 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buf.test.v1;
+
+public class Foo {
+    public static void test() {
+        Test.BasicMessage.newBuilder().build();
+    }
+}

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_default_template_file_path_explicitly_specifying_v2/workspace/buf/test/v1/test.proto
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_default_template_file_path_explicitly_specifying_v2/workspace/buf/test/v1/test.proto
@@ -1,0 +1,21 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.test.v1;
+
+option java_package = "buf.test.v1";
+
+message BasicMessage {}


### PR DESCRIPTION
Note that `BreakingWithProtobufGradleTest/schema_with_multi_directory_workspace` is set to use an older Buf version because I have not been able to create a suitable `v2` `buf.yaml` to handle that case correctly.