### PR TITLE
Update tests to use local generation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     alias(libs.plugins.buildConfig)
     alias(libs.plugins.kotlin)
     alias(libs.plugins.mavenPublish)
+    alias(libs.plugins.osDetector)
     alias(libs.plugins.pluginPublish)
     alias(libs.plugins.spotless)
 }
@@ -33,6 +34,7 @@ allprojects {
 }
 
 val bufCliDependabotConfig = configurations.create("bufCliDependabotConfig")
+val protoc: Configuration by configurations.creating
 
 dependencies {
     // Trigger dependabot on a new Buf CLI release.
@@ -44,6 +46,7 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)
+    protoc("com.google.protobuf:protoc:${libs.versions.protoc.get()}:${osdetector.classifier}@exe")
 }
 
 object ProjectInfo {
@@ -119,6 +122,8 @@ tasks {
 
     withType<Test> {
         useJUnitPlatform()
+
+        systemProperty("protoc.path", protoc.asPath)
     }
 
     withType<KotlinCompile> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 # plugins
 kotlin = "1.9.24"
 mavenPublish = "0.29.0"
+osDetector = "1.7.3"
 pluginPublish = "1.2.1"
 spotless = "6.25.0"
 buildConfig = "5.4.0"
@@ -9,6 +10,7 @@ buildConfig = "5.4.0"
 # runtime
 bufbuild = "1.38.0"
 jackson = "2.17.2"
+protoc = "3.23.4"
 versioncompare = "1.5.0"
 
 # test
@@ -19,6 +21,7 @@ truth = "1.4.4"
 buildConfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildConfig" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 mavenPublish = { id = "com.vanniktech.maven.publish.base", version.ref = "mavenPublish" }
+osDetector = { id = "com.google.osdetector", version.ref = "osDetector" }
 pluginPublish = { id = "com.gradle.plugin-publish", version.ref = "pluginPublish" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 
@@ -27,6 +30,7 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 bufbuild = { module = "build.buf:buf", version.ref = "bufbuild" }
 jacksonDataformatYaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
 jacksonModuleKotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
+protoc = { module = "com.google.protobuf:protoc", version.ref = "protoc" }
 versioncompare = { module = "io.github.g00fy2:versioncompare", version.ref = "versioncompare" }
 
 # test

--- a/src/test/kotlin/build/buf/gradle/AbstractBufIntegrationTest.kt
+++ b/src/test/kotlin/build/buf/gradle/AbstractBufIntegrationTest.kt
@@ -36,7 +36,7 @@ abstract class AbstractBufIntegrationTest : IntegrationTest {
         get() = Paths.get(projectDir.path, "src", "main", "proto").toFile()
 
     @BeforeEach
-    open fun setup(testInfo: TestInfo) {
+    fun setup(testInfo: TestInfo) {
         File(projectDir, "settings.gradle").writeText("rootProject.name = 'testing'")
         File(projectDir, "gradle.properties").writeText("org.gradle.jvmargs=-Xmx5g")
 

--- a/src/test/kotlin/build/buf/gradle/AbstractBufIntegrationTest.kt
+++ b/src/test/kotlin/build/buf/gradle/AbstractBufIntegrationTest.kt
@@ -36,7 +36,7 @@ abstract class AbstractBufIntegrationTest : IntegrationTest {
         get() = Paths.get(projectDir.path, "src", "main", "proto").toFile()
 
     @BeforeEach
-    fun setup(testInfo: TestInfo) {
+    open fun setup(testInfo: TestInfo) {
         File(projectDir, "settings.gradle").writeText("rootProject.name = 'testing'")
         File(projectDir, "gradle.properties").writeText("org.gradle.jvmargs=-Xmx5g")
 

--- a/src/test/kotlin/build/buf/gradle/AbstractGenerateTest.kt
+++ b/src/test/kotlin/build/buf/gradle/AbstractGenerateTest.kt
@@ -18,25 +18,20 @@ import com.google.common.truth.Truth.assertThat
 import org.gradle.language.base.plugins.LifecycleBasePlugin.BUILD_TASK_NAME
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInfo
 import java.io.File
-import java.nio.file.Files
 import java.nio.file.Paths
-import kotlin.io.path.isRegularFile
-import kotlin.io.path.name
 
 abstract class AbstractGenerateTest : AbstractBufIntegrationTest() {
     @BeforeEach
-    override fun setup(testInfo: TestInfo) {
-        super.setup(testInfo)
-        val protocPath = System.getProperty("protoc.path") ?: throw RuntimeException("protoc.path not set")
+    fun configureBufGenYamlProtocPath() {
+        val protocPath = System.getProperty("protoc.path") ?: error("protoc.path not set")
         val protocFile = File(protocPath)
         if (!protocFile.canExecute()) {
             protocFile.setExecutable(true)
         }
-        Files.walk(super.projectDir.toPath()).forEach { path ->
-            if (path.name == "buf.gen.yaml" && path.isRegularFile()) {
-                path.toFile().replace("PROTOC_PATH", protocFile.absolutePath)
+        projectDir.walkTopDown().forEach { file ->
+            if (file.name == "buf.gen.yaml") {
+                file.replace("PROTOC_PATH", protocFile.absolutePath)
             }
         }
     }

--- a/src/test/resources/GenerateTest/buf_generate_fails_when_a_specified_template_file_does_not_exist_but_a_default_one_does/buf.gen.yaml
+++ b/src/test/resources/GenerateTest/buf_generate_fails_when_a_specified_template_file_does_not_exist_but_a_default_one_does/buf.gen.yaml
@@ -1,4 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: java
+    # Replaced with full path to protoc in test setup.
+    protoc_path: PROTOC_PATH
     out: java

--- a/src/test/resources/GenerateTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/buf.gen.yaml
+++ b/src/test/resources/GenerateTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/buf.gen.yaml
@@ -1,4 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: java
+    # Replaced with full path to protoc in test setup.
+    protoc_path: PROTOC_PATH
     out: java

--- a/src/test/resources/GenerateTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/subdir/buf.gen.yaml
+++ b/src/test/resources/GenerateTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/subdir/buf.gen.yaml
@@ -1,4 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: java
+    # Replaced with full path to protoc in test setup.
+    protoc_path: PROTOC_PATH
     out: java

--- a/src/test/resources/GenerateTest/buf_generate_with_buf_gen_template_file_override/subdir/buf.gen.yaml
+++ b/src/test/resources/GenerateTest/buf_generate_with_buf_gen_template_file_override/subdir/buf.gen.yaml
@@ -1,4 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: java
+    # Replaced with full path to protoc in test setup.
+    protoc_path: PROTOC_PATH
     out: java

--- a/src/test/resources/GenerateTest/buf_generate_with_default_template_file_path_explicitly_specifying/buf.gen.yaml
+++ b/src/test/resources/GenerateTest/buf_generate_with_default_template_file_path_explicitly_specifying/buf.gen.yaml
@@ -1,4 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: java
+    # Replaced with full path to protoc in test setup.
+    protoc_path: PROTOC_PATH
     out: java

--- a/src/test/resources/GenerateTest/generate_java/buf.gen.yaml
+++ b/src/test/resources/GenerateTest/generate_java/buf.gen.yaml
@@ -1,4 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: java
+    # Replaced with full path to protoc in test setup.
+    protoc_path: PROTOC_PATH
     out: java

--- a/src/test/resources/GenerateTest/generate_java_with_include_imports/buf.gen.yaml
+++ b/src/test/resources/GenerateTest/generate_java_with_include_imports/buf.gen.yaml
@@ -1,4 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: java
+    # Replaced with full path to protoc in test setup.
+    protoc_path: PROTOC_PATH
     out: java

--- a/src/test/resources/GenerateTest/generate_java_with_kotlin_dsl/buf.gen.yaml
+++ b/src/test/resources/GenerateTest/generate_java_with_kotlin_dsl/buf.gen.yaml
@@ -1,4 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: java
+    # Replaced with full path to protoc in test setup.
+    protoc_path: PROTOC_PATH
     out: java

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_when_a_specified_template_file_does_not_exist_but_a_default_one_does/buf.gen.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_when_a_specified_template_file_does_not_exist_but_a_default_one_does/buf.gen.yaml
@@ -1,4 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: java
+    # Replaced with full path to protoc in test setup.
+    protoc_path: PROTOC_PATH
     out: java

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/buf.gen.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/buf.gen.yaml
@@ -1,4 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: java
+    # Replaced with full path to protoc in test setup.
+    protoc_path: PROTOC_PATH
     out: java

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/subdir/buf.gen.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_fails_with_both_default_and_specified_buf_gen_template_files/subdir/buf.gen.yaml
@@ -1,4 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: java
+    # Replaced with full path to protoc in test setup.
+    protoc_path: PROTOC_PATH
     out: java

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_buf_gen_template_file_override/subdir/buf.gen.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_buf_gen_template_file_override/subdir/buf.gen.yaml
@@ -1,4 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: java
+    # Replaced with full path to protoc in test setup.
+    protoc_path: PROTOC_PATH
     out: java

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_default_template_file_path_explicitly_specifying/buf.gen.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_default_template_file_path_explicitly_specifying/buf.gen.yaml
@@ -1,4 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: java
+    # Replaced with full path to protoc in test setup.
+    protoc_path: PROTOC_PATH
     out: java

--- a/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_default_template_file_path_explicitly_specifying_v2/buf.gen.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/buf_generate_with_default_template_file_path_explicitly_specifying_v2/buf.gen.yaml
@@ -1,4 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: java
+    # Replaced with full path to protoc in test setup.
+    protoc_path: PROTOC_PATH
     out: java

--- a/src/test/resources/GenerateWithWorkspaceTest/generate_java/buf.gen.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/generate_java/buf.gen.yaml
@@ -1,4 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: java
+    # Replaced with full path to protoc in test setup.
+    protoc_path: PROTOC_PATH
     out: java

--- a/src/test/resources/GenerateWithWorkspaceTest/generate_java_with_include_imports/buf.gen.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/generate_java_with_include_imports/buf.gen.yaml
@@ -1,4 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: java
+    # Replaced with full path to protoc in test setup.
+    protoc_path: PROTOC_PATH
     out: java

--- a/src/test/resources/GenerateWithWorkspaceTest/generate_java_with_kotlin_dsl/buf.gen.yaml
+++ b/src/test/resources/GenerateWithWorkspaceTest/generate_java_with_kotlin_dsl/buf.gen.yaml
@@ -1,4 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: java
+    # Replaced with full path to protoc in test setup.
+    protoc_path: PROTOC_PATH
     out: java


### PR DESCRIPTION
Update gradle tests to use local generation instead of remote plugins, which allows test to be run offline and also avoid rate limiting for unauthenticated generation requests.
