### PR TITLE
Add test using v1 lint config with inter-module dependencies that must run on Buf 1.31.0

### DIFF
--- a/src/test/kotlin/build/buf/gradle/LintWithProtobufGradleTest.kt
+++ b/src/test/kotlin/build/buf/gradle/LintWithProtobufGradleTest.kt
@@ -14,7 +14,10 @@
 
 package build.buf.gradle
 
+import com.google.common.truth.Truth.assertThat
+import org.gradle.language.base.plugins.LifecycleBasePlugin.CHECK_TASK_NAME
 import org.junit.jupiter.api.Test
+import java.nio.file.Paths
 
 class LintWithProtobufGradleTest : ConfigOverrideableLintTests, AbstractLintTest() {
     @Test
@@ -39,6 +42,16 @@ class LintWithProtobufGradleTest : ConfigOverrideableLintTests, AbstractLintTest
 
     @Test
     fun `lint a file with an implementation dependency and a google dependency with the protobuf-gradle-plugin`() {
+        assertSuccess()
+    }
+
+    @Test
+    fun `lint a file with an implementation dependency and a lint config with the protobuf-gradle-plugin`() {
+        val result = gradleRunner().withArguments(":$CHECK_TASK_NAME").buildAndFail()
+        assertThat(result.output).contains("Enum zero value name \"BROKEN_ENUM_NONSPECIFIED\" should be suffixed with \"_UNSPECIFIED\"")
+
+        Paths.get(projectDir.path, "buf.yaml").toFile().replace("#", "")
+
         assertSuccess()
     }
 }

--- a/src/test/kotlin/build/buf/gradle/LintWithProtobufGradleTest.kt
+++ b/src/test/kotlin/build/buf/gradle/LintWithProtobufGradleTest.kt
@@ -14,10 +14,7 @@
 
 package build.buf.gradle
 
-import com.google.common.truth.Truth.assertThat
-import org.gradle.language.base.plugins.LifecycleBasePlugin.CHECK_TASK_NAME
 import org.junit.jupiter.api.Test
-import java.nio.file.Paths
 
 class LintWithProtobufGradleTest : ConfigOverrideableLintTests, AbstractLintTest() {
     @Test
@@ -47,11 +44,6 @@ class LintWithProtobufGradleTest : ConfigOverrideableLintTests, AbstractLintTest
 
     @Test
     fun `lint a file with an implementation dependency and a lint config with the protobuf-gradle-plugin`() {
-        val result = gradleRunner().withArguments(":$CHECK_TASK_NAME").buildAndFail()
-        assertThat(result.output).contains("Enum zero value name \"BROKEN_ENUM_NONSPECIFIED\" should be suffixed with \"_UNSPECIFIED\"")
-
-        Paths.get(projectDir.path, "buf.yaml").toFile().replace("#", "")
-
         assertSuccess()
     }
 }

--- a/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_a_lint_config_with_the_protobuf_gradle_plugin/buf.yaml
+++ b/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_a_lint_config_with_the_protobuf_gradle_plugin/buf.yaml
@@ -6,4 +6,4 @@ lint:
   use:
     - DEFAULT
   except:
-    #- ENUM_ZERO_VALUE_SUFFIX
+    - ENUM_ZERO_VALUE_SUFFIX

--- a/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_a_lint_config_with_the_protobuf_gradle_plugin/buf.yaml
+++ b/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_a_lint_config_with_the_protobuf_gradle_plugin/buf.yaml
@@ -1,0 +1,9 @@
+version: v1
+lint:
+  ignore:
+    - google
+    - protokt
+  use:
+    - DEFAULT
+  except:
+    #- ENUM_ZERO_VALUE_SUFFIX

--- a/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_a_lint_config_with_the_protobuf_gradle_plugin/build.gradle
+++ b/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_a_lint_config_with_the_protobuf_gradle_plugin/build.gradle
@@ -14,6 +14,10 @@ protobuf {
   }
 }
 
+buf {
+  toolVersion = "1.31.0"
+}
+
 compileJava.enabled = false
 
 dependencies {

--- a/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_a_lint_config_with_the_protobuf_gradle_plugin/build.gradle
+++ b/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_a_lint_config_with_the_protobuf_gradle_plugin/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+  id 'java'
+  id 'com.google.protobuf' version "$protobufGradleVersion"
+  id 'build.buf'
+}
+
+repositories {
+  mavenCentral()
+}
+
+protobuf {
+  protoc {
+    artifact = "com.google.protobuf:protoc:$protobufVersion"
+  }
+}
+
+compileJava.enabled = false
+
+dependencies {
+  implementation "com.google.protobuf:protobuf-java:$protobufVersion"
+  implementation "com.toasttab.protokt:protokt-runtime:0.6.5"
+}

--- a/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_a_lint_config_with_the_protobuf_gradle_plugin/src/main/proto/buf/test/v1/test.proto
+++ b/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_a_lint_config_with_the_protobuf_gradle_plugin/src/main/proto/buf/test/v1/test.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Buf Technologies, Inc.
+// Copyright 2024 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_a_lint_config_with_the_protobuf_gradle_plugin/src/main/proto/buf/test/v1/test.proto
+++ b/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_a_lint_config_with_the_protobuf_gradle_plugin/src/main/proto/buf/test/v1/test.proto
@@ -1,0 +1,29 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.test.v1;
+
+import "google/protobuf/any.proto";
+import "protokt/protokt.proto";
+
+message BasicMessage {
+  google.protobuf.Any any = 1;
+  protokt.ProtoktFileOptions protokt_file_options = 2;
+
+  enum BrokenEnum {
+    BROKEN_ENUM_NONSPECIFIED = 0; // should be _UNSPECIFIED
+  }
+}

--- a/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_a_lint_config_with_the_protobuf_gradle_plugin/src/main/proto/buf/test/v1/test.proto
+++ b/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_a_lint_config_with_the_protobuf_gradle_plugin/src/main/proto/buf/test/v1/test.proto
@@ -16,12 +16,10 @@ syntax = "proto3";
 
 package buf.test.v1;
 
-import "google/protobuf/any.proto";
 import "protokt/protokt.proto";
 
 message BasicMessage {
-  google.protobuf.Any any = 1;
-  protokt.ProtoktFileOptions protokt_file_options = 2;
+  protokt.ProtoktFileOptions protokt_file_options = 1;
 
   enum BrokenEnum {
     BROKEN_ENUM_NONSPECIFIED = 0; // should be _UNSPECIFIED


### PR DESCRIPTION
This PR introduces a test that passes with Buf pinned to 1.31.0 but fails when on latest. The failure with newer versions of Buf is:

```
     * What went wrong:
    Execution failed for task ':bufLint'.
    > Some Protobuf files had lint violations:
      src-main-proto/buf/test/v1/test.proto:20:8:import "protokt/protokt.proto": file does not exist
```