### PR TITLE
Improve error message when task with custom error handler fails with no stdout

### DIFF
--- a/src/main/kotlin/build/buf/gradle/BufSupport.kt
+++ b/src/main/kotlin/build/buf/gradle/BufSupport.kt
@@ -84,13 +84,6 @@ internal fun AbstractBufExecTask.execBuf(
     handleResult(result, customErrorMessage)
 }
 
-internal fun AbstractBufExecTask.obtainDefaultProtoFileSet() =
-    project.fileTree(workingDir.get()) {
-        include("**/*.proto")
-        // not to interfere with random plugins producing output to build dir
-        exclude("build")
-    }
-
 @VisibleForTesting
 internal fun handleResult(
     result: ProcessRunner.Result,
@@ -114,3 +107,10 @@ internal fun handleResult(
         }
     }
 }
+
+internal fun AbstractBufExecTask.obtainDefaultProtoFileSet() =
+    project.fileTree(workingDir.get()) {
+        include("**/*.proto")
+        // not to interfere with random plugins producing output to build dir
+        exclude("build")
+    }

--- a/src/test/kotlin/build/buf/gradle/BufSupportTest.kt
+++ b/src/test/kotlin/build/buf/gradle/BufSupportTest.kt
@@ -1,0 +1,38 @@
+// Copyright 2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buf.gradle
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class BufSupportTest {
+    @Test
+    fun `handleResult includes stderr when stdout is empty and custom error message is specified`() {
+        val thrown =
+            assertThrows<IllegalStateException> {
+                handleResult(
+                    ProcessRunner.Result(
+                        emptyList(),
+                        1,
+                        "".toByteArray(),
+                        "error that would be hidden".toByteArray(),
+                    ),
+                ) { "foo" }
+            }
+
+        assertThat(thrown).hasMessageThat().contains("error that would be hidden")
+    }
+}


### PR DESCRIPTION
This would allow the `buf breaking` [test that requires Buf 1.31.0](https://github.com/bufbuild/buf-gradle-plugin/pull/213/files#diff-dbe62edf00cb02d5ffc116d39393f9a9dd0a2f2cccb2d92b5f6d8ba529d16b03R19) to fail with an actual error message rather than silence.

When this line is removed, the test now fails with the correct error message, which is this one: https://github.com/bufbuild/buf/issues/567