### PR TITLE
Build plugin with Java 17 and pin GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,37 +17,37 @@ jobs:
       checks: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
-      - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: gradle/actions/wrapper-validation@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0
+      - name: Set up JDK 17
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           check-latest: true
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0
       - name: Build
         run: ./gradlew build --info
       - name: Publish unit test results (Ubuntu)
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@3a74b2957438d0b6e2e61d67b05318aa25c9e6c6 # v2.20.0
         if: always() && matrix.os == 'ubuntu-latest'
         with:
           files: "**/test-results/**/*.xml"
           comment_mode: off
           check_name: "Test Results (Ubuntu)"
       - name: Publish unit test results (Windows)
-        uses: EnricoMi/publish-unit-test-result-action/windows@v2
+        uses: EnricoMi/publish-unit-test-result-action/windows@3a74b2957438d0b6e2e61d67b05318aa25c9e6c6 # v2.20.0
         if: always() && matrix.os == 'windows-latest'
         with:
           files: "**/test-results/**/*.xml"
           comment_mode: off
           check_name: "Test Results (Windows)"
       - name: Publish unit test results (MacOS)
-        uses: EnricoMi/publish-unit-test-result-action/macos@v2
+        uses: EnricoMi/publish-unit-test-result-action/macos@3a74b2957438d0b6e2e61d67b05318aa25c9e6c6 # v2.20.0
         if: always() && matrix.os == 'macos-latest'
         with:
           files: "**/test-results/**/*.xml"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,19 +12,19 @@ jobs:
     environment: publication
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
-      - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: gradle/actions/wrapper-validation@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0
+      - name: Set up JDK 17
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           check-latest: true
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0
       - name: Publish
         run: |
           ./gradlew \

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,7 @@ buildscript { repositories { gradlePluginPortal() } }
 
 plugins {
     id("io.alcide.gradle-semantic-build-versioning") version "4.2.2"
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 rootProject.name = "buf-gradle-plugin"


### PR DESCRIPTION
Update the plugin to build with Java 17 (required for the latest foojay-resolver-convention plugin) and pin GitHub actions.