### PR TITLE
New (currently failing) test for clashing direct and indirect dependencies

### DIFF
--- a/src/test/kotlin/build/buf/gradle/LintWithProtobufGradleTest.kt
+++ b/src/test/kotlin/build/buf/gradle/LintWithProtobufGradleTest.kt
@@ -58,4 +58,9 @@ class LintWithProtobufGradleTest :
     fun `lint a file with an implementation dependency and a lint config with the protobuf-gradle-plugin v2`() {
         assertSuccess()
     }
+
+    @Test
+    fun `lint a file with an implementation dependency and the same package as an indirect protobuf dependency`() {
+        assertSuccess()
+    }
 }

--- a/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_the_same_package_as_an_indirect_protobuf_dependency/build.gradle
+++ b/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_the_same_package_as_an_indirect_protobuf_dependency/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+  id 'java'
+  id 'com.google.protobuf' version "$protobufGradleVersion"
+  id 'build.buf'
+}
+
+repositories {
+  mavenCentral()
+}
+
+protobuf {
+  protoc {
+    artifact = "com.google.protobuf:protoc:$protobufVersion"
+  }
+}
+
+compileJava.enabled = false
+
+dependencies {
+  implementation "com.google.protobuf:protobuf-java:$protobufVersion"
+  protobuf 'io.grpc:grpc-protobuf:1.75.0'
+}

--- a/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_the_same_package_as_an_indirect_protobuf_dependency/src/main/proto/buf/test/v1/test.proto
+++ b/src/test/resources/LintWithProtobufGradleTest/lint_a_file_with_an_implementation_dependency_and_the_same_package_as_an_indirect_protobuf_dependency/src/main/proto/buf/test/v1/test.proto
@@ -1,0 +1,23 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.test.v1;
+
+import "google/protobuf/any.proto";
+
+message BasicMessage {
+  google.protobuf.Any any = 1;
+}


### PR DESCRIPTION
Similar to https://github.com/bufbuild/buf-gradle-plugin/issues/132, and possibly a regression introduced by https://github.com/bufbuild/buf-gradle-plugin/pull/206.

The `implementation "com.google.protobuf:protobuf-java:$protobufVersion"` dependency causes Google's Protobuf Gradle plugin to place well-known-type protos in `build/extracted-include-protos` and the `protobuf 'io.grpc:grpc-protobuf:1.75.0'` dependency itself depends on the above `protobuf-java` package and thus causes Google's plugin to put the same well-known-type protos in the `build/extracted-protos` directory.

Then the Buf Gradle plugin adds both those directories as modules in its derived `buf.yaml` (`build/bufbuild/buf.yaml`) and the linter errors out over the ambiguity:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':bufLint'.
> Some Protobuf files had lint violations:
  src-main-proto/buf/test/v1/test.proto:19:8:google/protobuf/any.proto is contained in multiple modules:
    path: "build-extracted--include--protos-main"
    path: "build-extracted--protos-main"
```