### PR TITLE
Update to Jackson 3.x and snakeyaml-engine

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,7 +80,7 @@ ext[GRADLE_PUBLISH_SECRET] = System.getenv("GRADLE_PORTAL_PUBLISH_SECRET")
 
 kotlin {
     jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ buildConfig = "5.6.8"
 
 # runtime
 bufbuild = "1.59.0"
-jackson = "2.20.0"
+jackson = "3.0.1"
 protoc = "4.33.0"
 versioncompare = "1.5.0"
 
@@ -31,8 +31,8 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 [libraries]
 # runtime
 bufbuild = { module = "build.buf:buf", version.ref = "bufbuild" }
-jacksonDataformatYaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
-jacksonModuleKotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
+jacksonDataformatYaml = { module = "tools.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
+jacksonModuleKotlin = { module = "tools.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 protoc = { module = "com.google.protobuf:protoc", version.ref = "protoc" }
 versioncompare = { module = "io.github.g00fy2:versioncompare", version.ref = "versioncompare" }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/build/buf/gradle/BufYamlGenerator.kt
+++ b/src/main/kotlin/build/buf/gradle/BufYamlGenerator.kt
@@ -1,13 +1,17 @@
 package build.buf.gradle
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.fasterxml.jackson.module.kotlin.readValue
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import tools.jackson.dataformat.yaml.YAMLFactory
+import tools.jackson.dataformat.yaml.YAMLMapper
+import tools.jackson.module.kotlin.KotlinModule
+import tools.jackson.module.kotlin.readValue
 import java.io.File
 
 internal class BufYamlGenerator {
-    private val mapper = ObjectMapper(YAMLFactory()).registerKotlinModule()
+    private val mapper =
+        YAMLMapper
+            .builder(YAMLFactory.builder().build())
+            .addModule(KotlinModule.Builder().build())
+            .build()
 
     /**
      * Read the user-supplied buf.yaml file and generate an equivalent file, adding a


### PR DESCRIPTION
Users that are using snakeyaml (1.x or 2.x) may encounter issues with the buf-gradle-plugin. Updating to Jackson 3.x changes the YAML support to use snakeyaml-engine which doesn't have the same compatibility issues, and this gets us on a newer baseline for YAML support in the plugin.

The only caveat is that Jackson 3.x requires Java 17, so the plugin will require that Gradle is run with Java 17+. This is similar to other plugins in the ecosystem and Gradle 9 also requires Java 17.

Fixes #356.
