### PR TITLE
Update to buf 1.68.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ spotless = "8.4.0"
 buildConfig = "6.0.9"
 
 # runtime
-bufbuild = "1.67.0"
+bufbuild = "1.68.4"
 jackson = "3.1.2"
 protoc = "4.34.1"
 versioncompare = "1.5.0"

--- a/src/test/kotlin/build/buf/gradle/AbstractBuildTest.kt
+++ b/src/test/kotlin/build/buf/gradle/AbstractBuildTest.kt
@@ -67,10 +67,8 @@ abstract class AbstractBuildTest : AbstractBufIntegrationTest() {
     @Test
     fun `build an image reusing an extension number`() {
         val result = buildRunner().buildAndFail()
-        val source = listOf("buf", "test", "v1", "test.proto").joinToString(File.separator)
         assertThat(result.output).contains(
-            "$source:23:14:extension with tag 1072 for message google.protobuf.MessageOptions already defined at " +
-                "validate/validate.proto:17:29",
+            "field number `1072` used more than once",
         )
     }
 


### PR DESCRIPTION
Update buf-gradle-plugin to the latest version of the CLI. Update test assertion to match the new error message for re-using an extension number.