### PR TITLE
remove check that forbids using the templateFileLocation generate option if a default buf.gen.yaml exists in the project directory

### DIFF
--- a/src/main/kotlin/build/buf/gradle/GenerateConfiguration.kt
+++ b/src/main/kotlin/build/buf/gradle/GenerateConfiguration.kt
@@ -42,9 +42,6 @@ private fun Project.resolveTemplateFile(generateOptions: GenerateOptions): File 
         check(specifiedTemplateFile != null) {
             "Specified templateFileLocation does not exist."
         }
-        check(defaultTemplateFile == null || specifiedTemplateFile == defaultTemplateFile) {
-            "Buf gen template file specified in the project directory as well as with templateFileLocation; pick one."
-        }
         specifiedTemplateFile
     } else {
         check(defaultTemplateFile != null) {


### PR DESCRIPTION
This change is intended to allow consumer projects to keep a default `bug.gen.yaml` in the project directory along side secondary ones that are passed to the plugin via the `templateFileLocation` generate option

At the moment the above is not possible. Consumer projects have to delete `bug.gen.yml` to avoid the error when they want to generate with a template that uses a different name

Use case: project wants to use `buf.gen.yaml` for public builds, and wants to keep a separate `buf.private.gen.yaml` to build a wider set of proto module directories