### PR TITLE
Compare image to image in bufBreaking with the protobuf-gradle-plugin

### DIFF
--- a/src/main/kotlin/build/buf/gradle/BreakingConfiguration.kt
+++ b/src/main/kotlin/build/buf/gradle/BreakingConfiguration.kt
@@ -56,12 +56,8 @@ private fun Project.configureBreakingTask() {
 
         dependsOn(BUF_BUILD_TASK_NAME)
 
-        if (project.bufV1SyntaxOnly()) {
-            v1SyntaxOnly.set(true)
-            publicationFile.set(project.bufBuildPublicationFile)
-        } else {
-            v1SyntaxOnly.set(false)
-        }
+        v1SyntaxOnly.set(project.bufV1SyntaxOnly())
+        publicationFile.set(project.bufBuildPublicationFile)
         configFile.set(singleFileFromConfiguration(BUF_BREAKING_CONFIGURATION_NAME))
     }
 }

--- a/src/main/kotlin/build/buf/gradle/BreakingTask.kt
+++ b/src/main/kotlin/build/buf/gradle/BreakingTask.kt
@@ -44,7 +44,10 @@ abstract class BreakingTask : AbstractBufExecTask() {
     fun bufBreaking() {
         val args = mutableListOf<Any>()
         args.add("breaking")
-        if (v1SyntaxOnly.get()) {
+        // For a generated multi-module workspace, buf compares a directory input
+        // module-by-module against the baseline image and reports spurious deletions
+        // (https://github.com/bufbuild/buf/issues/3654), so compare image to image.
+        if (v1SyntaxOnly.get() || hasProtobufGradlePlugin.get()) {
             args.add(publicationFile.get())
         }
         args.add("--against")

--- a/src/main/kotlin/build/buf/gradle/BreakingTask.kt
+++ b/src/main/kotlin/build/buf/gradle/BreakingTask.kt
@@ -44,9 +44,6 @@ abstract class BreakingTask : AbstractBufExecTask() {
     fun bufBreaking() {
         val args = mutableListOf<Any>()
         args.add("breaking")
-        // For a generated multi-module workspace, buf compares a directory input
-        // module-by-module against the baseline image and reports spurious deletions
-        // (https://github.com/bufbuild/buf/issues/3654), so compare image to image.
         if (v1SyntaxOnly.get() || hasProtobufGradlePlugin.get()) {
             args.add(publicationFile.get())
         }

--- a/src/test/resources/BreakingWithProtobufGradleTest/schema_with_multi_directory_workspace/build.gradle
+++ b/src/test/resources/BreakingWithProtobufGradleTest/schema_with_multi_directory_workspace/build.gradle
@@ -25,7 +25,6 @@ publishing {
 }
 
 buf {
-  toolVersion = "1.31.0"
   publishSchema = true
   //checkSchemaAgainstLatestRelease = true
 


### PR DESCRIPTION
When the protobuf-gradle-plugin is applied, this plugin generates a v2 `buf.yaml` with one module per proto source directory. On buf >= 1.32, `bufBreaking` runs `buf breaking --against <baseline image>` with the working directory as input. Buf pairs the workspace's modules against the baseline image module-by-module, so every module after the first is compared against the wrong baseline and buf reports unchanged files as deleted:

```
<input>:1:1:Previously present file "bar/v1/bar.proto" was deleted.
```

This is https://github.com/bufbuild/buf/issues/3654, which was closed with `--against-registry`; that flag doesn't apply here because we're comparing to a Maven artifact.

This was already known: `BreakingWithProtobufGradleTest > schema with multi-directory workspace` is pinned to `toolVersion = "1.31.0"` (#214 noted a suitable v2 `buf.yaml` couldn't be found for that case). 

When the protobuf-gradle-plugin is in play (the only case where the plugin generates the multi-module workspace), the plugin now passes the freshly built image as the input, comparing image to image just like the v1 path always has.